### PR TITLE
fix: replace incorrect branch key with correct branches key in releaserc file

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,7 @@
 {
-  "branch": "main",
+  "branches": [
+    "main"
+  ],
   "tagFormat": "v${version}",
   "verifyConditions": [
     "@semantic-release/npm",


### PR DESCRIPTION
The release GitHub action on the previous pull request failed with the following error.

>
    SemanticReleaseError: The release branches are invalid in the `branches` configuration.
        at default (file:///home/runner/work/frontend-lib-learning-assistant/frontend-lib-learning-assistant/node_modules/semantic-release/lib/get-error.js:6:10)
        at file:///home/runner/work/frontend-lib-learning-assistant/frontend-lib-learning-assistant/node_modules/semantic-release/lib/branches/index.js:45:19
        at Array.reduce (<anonymous>)
        at default (file:///home/runner/work/frontend-lib-learning-assistant/frontend-lib-learning-assistant/node_modules/semantic-release/lib/branches/index.js:35:[46](https://github.com/edx/frontend-lib-learning-assistant/actions/runs/5754323807/job/15599367963#step:7:47))
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at async run (file:///home/runner/work/frontend-lib-learning-assistant/frontend-lib-learning-assistant/node_modules/semantic-release/index.js:68:22)
        at async Module.default (file:///home/runner/work/frontend-lib-learning-assistant/frontend-lib-learning-assistant/node_modules/semantic-release/index.js:275:22)
        at async default (file:///home/runner/work/frontend-lib-learning-assistant/frontend-lib-learning-assistant/node_modules/semantic-release/cli.js:55:5) {
      code: 'ERELEASEBRANCHES',
      details: 'A minimum of 1 and a maximum of 3 release branches are required in the [branches configuration](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches).\n' +
        '\n' +
        'This may occur if your repository does not have a release branch, such as `master`.\n' +
        '\n' +
        'Your configuration for the problematic branches is `[]`.',
      semanticRelease: true
    }


I copied the `.releaserc` file from [frontend-lib-special-exams](https://github.com/openedx/frontend-lib-special-exams/blob/main/.releaserc) and forgot to rename `branch` to `branches`. `branches` is used by [semantic-release](https://semantic-release.gitbook.io/semantic-release/) to determine which Git branches to release; see [here](https://semantic-release.gitbook.io/semantic-release/usage/configuration#branches). This is necessary because we release on a non-standard `main` branch - not `master`.