### PR TITLE
Change CSS button element selector to class selector in ToggleXpertButton component.

### DIFF
--- a/src/components/ToggleXpertButton/index.jsx
+++ b/src/components/ToggleXpertButton/index.jsx
@@ -18,7 +18,7 @@ const ToggleXpert = ({ isOpen, setIsOpen, courseId }) => {
   if (isOpen) {
     return (
       <button
-        className="open position-fixed d-flex flex-row bg-white p-2"
+        className="toggle open position-fixed d-flex flex-row bg-white p-2"
         data-testid="toggle-button"
         onClick={handleClick}
         type="button"
@@ -30,7 +30,7 @@ const ToggleXpert = ({ isOpen, setIsOpen, courseId }) => {
 
   return (
     <button
-      className="closed d-flex flex-column position-fixed justify-content-end align-items-end border-0"
+      className="toggle closed d-flex flex-column position-fixed justify-content-end align-items-end border-0"
       data-testid="toggle-button"
       onClick={handleClick}
       type="button"

--- a/src/components/ToggleXpertButton/index.scss
+++ b/src/components/ToggleXpertButton/index.scss
@@ -4,7 +4,7 @@
     bottom: 4rem;
 }
 
-button {
+.toggle {
     bottom: 1rem;
 
     &.open {


### PR DESCRIPTION
### Description

This commit changes the CSS button element selector in the `ToggleXpertButton` to a CSS class selector (i.e. `toggle`). This is because the button selector was being applied in the `frontend-app-learning application` and causing changes to the page style.

Eventually, it may be nice to use something like CSS modules or styled components to scope our CSS to this component, but, for now, this will do.

**JIRA**: [MST-2034](https://2u-internal.atlassian.net/browse/MST-2034) (private)

### Screenshots

**NOTE**: See the line above the video camera icon.

**Before**
<img width="1440" alt="Screenshot 2023-08-22 at 2 02 01 PM" src="https://github.com/edx/frontend-lib-learning-assistant/assets/11871801/e331c18d-1e91-4ab6-a900-8c8bdf6d0646">

**After**
<img width="1440" alt="Screenshot 2023-08-22 at 2 33 08 PM" src="https://github.com/edx/frontend-lib-learning-assistant/assets/11871801/ca0e1efc-bf25-4484-95aa-f3990aeb6826">
