### PR TITLE
feat: add error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "jest": "29.6.1",
         "react": "16.14.0",
         "react-dom": "16.14.0",
+        "react-intl": "^5.25.0",
         "react-redux": "7.2.9",
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "jest": "29.6.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
+    "react-intl": "^5.25.0",
     "react-redux": "7.2.9",
     "react-router": "5.2.1",
     "react-router-dom": "5.3.0",

--- a/src/components/APIError/index.jsx
+++ b/src/components/APIError/index.jsx
@@ -1,0 +1,31 @@
+import { useDispatch } from 'react-redux';
+import { Alert } from '@edx/paragon';
+import { Info } from '@edx/paragon/icons';
+import {
+  clearApiError,
+} from '../../data/thunks';
+
+const APIError = () => {
+  const dispatch = useDispatch();
+  const handleClose = () => {
+    dispatch(clearApiError());
+  };
+
+  return (
+    <Alert
+      variant="danger"
+      icon={Info}
+      dismissible
+      onClose={handleClose}
+    >
+      <Alert.Heading>
+        Xpert is unavailable
+      </Alert.Heading>
+      <p>
+        Please try again by sending another question.
+      </p>
+    </Alert>
+  );
+};
+
+export default APIError;

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Send } from 'react-feather';
 import PropTypes from 'prop-types';
 import ChatBox from '../ChatBox';
+import APIError from '../APIError';
 import './Sidebar.scss';
 import {
   addChatMessage,
@@ -17,7 +18,7 @@ const Sidebar = ({
   isOpen,
   setIsOpen,
 }) => {
-  const { messageList, currentMessage } = useSelector(state => state.learningAssistant);
+  const { messageList, currentMessage, apiError } = useSelector(state => state.learningAssistant);
   const chatboxContainerRef = useRef(null);
   const dispatch = useDispatch();
 
@@ -53,7 +54,7 @@ const Sidebar = ({
         requestAnimationFrame(scroll);
       }
     }
-  }, [messageList, isOpen]);
+  }, [messageList, isOpen, apiError]);
 
   const handleClick = () => {
     setIsOpen(false);
@@ -117,7 +118,15 @@ const Sidebar = ({
           chatboxContainerRef={chatboxContainerRef}
           messageList={messageList}
         />
-        <form className="d-flex flex-row p-2 mt-auto" onSubmit={handleSubmitMessage}>
+        {
+          apiError
+          && (
+            <div className="d-flex flex-column p-3 mt-auto">
+              <APIError />
+            </div>
+          )
+        }
+        <form className={`d-flex flex-row p-2 ${apiError ? 'mt-1' : 'mt-auto'}`} onSubmit={handleSubmitMessage}>
           <input
             type="text"
             value={currentMessage}

--- a/src/data/slice.js
+++ b/src/data/slice.js
@@ -29,6 +29,9 @@ export const learningAssistantSlice = createSlice({
     setApiError: (state) => {
       state.apiError = true;
     },
+    resetApiError: (state) => {
+      state.apiError = false;
+    },
     setApiIsLoading: (state, { payload }) => {
       state.apiIsLoading = payload;
     },
@@ -42,6 +45,7 @@ export const {
   resetMessages,
   setApiError,
   setApiIsLoading,
+  resetApiError,
 } = learningAssistantSlice.actions;
 
 export const {

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -7,6 +7,7 @@ import {
   setMessageList,
   setApiError,
   setApiIsLoading,
+  resetApiError,
 } from './slice';
 
 export function addChatMessage(role, content) {
@@ -25,6 +26,7 @@ export function addChatMessage(role, content) {
     const updatedMessageList = [...messageList, message];
     dispatch(setMessageList({ messageList: updatedMessageList }));
     dispatch(clearCurrentMessage());
+    dispatch(resetApiError());
     sendTrackEvent('edx.ui.lms.learning_assistant.message', {
       id: conversationId,
       timestamp: message.timestamp,
@@ -53,11 +55,18 @@ export function getChatResponse(courseId) {
 export function clearMessages() {
   return (dispatch) => {
     dispatch(resetMessages());
+    dispatch(resetApiError());
   };
 }
 
 export function updateCurrentMessage(content) {
   return (dispatch) => {
     dispatch(setCurrentMessage({ currentMessage: content }));
+  };
+}
+
+export function clearApiError() {
+  return (dispatch) => {
+    dispatch(resetApiError());
   };
 }

--- a/src/utils/utils.test.jsx
+++ b/src/utils/utils.test.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { render } from '@testing-library/react';
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
+import { IntlProvider } from 'react-intl';
 import { reducer as learningAssistantReducer } from '../data/slice';
 
 function renderWithProviders(
@@ -16,7 +17,9 @@ function renderWithProviders(
   } = {},
 ) {
   const Wrapper = ({ children }) => (
-    <Provider store={store}>{children}</Provider>
+    <IntlProvider locale="en">
+      <Provider store={store}>{children}</Provider>
+    </IntlProvider>
   );
 
   Wrapper.propTypes = {

--- a/src/widgets/Xpert.test.jsx
+++ b/src/widgets/Xpert.test.jsx
@@ -20,7 +20,7 @@ const initialState = {
 };
 const courseId = 'course-v1:edX+DemoX+Demo_Course';
 
-const assertSidebarElementsInDOM = () => {
+const assertSidebarElementsNotInDOM = () => {
   expect(screen.queryByTestId('heading', { name: 'Hi, I\'m Xpert!' })).not.toBeInTheDocument();
   expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   expect(screen.queryByTestId('submit-button')).not.toBeInTheDocument();
@@ -40,7 +40,7 @@ test('initial load displays correct elements', () => {
   expect(screen.getByRole('button', { name: 'Have a question?' })).toBeVisible();
 
   // assert that UI elements in the sidebar are not in the DOM
-  assertSidebarElementsInDOM();
+  assertSidebarElementsNotInDOM();
 });
 test('clicking the toggle button opens the sidebar', async () => {
   const user = userEvent.setup();
@@ -157,7 +157,7 @@ test('clicking the close button closes the sidebar', async () => {
   await user.click(screen.getByTestId('close-button'));
 
   // assert that UI elements in the sidebar are not in the DOM
-  assertSidebarElementsInDOM();
+  assertSidebarElementsNotInDOM();
 });
 test('clicking the toggle button closes the sidebar', async () => {
   const user = userEvent.setup();
@@ -167,5 +167,74 @@ test('clicking the toggle button closes the sidebar', async () => {
   await user.click(screen.getByTestId('toggle-button'));
 
   // assert that UI elements in the sidebar are not in the DOM
-  assertSidebarElementsInDOM();
+  assertSidebarElementsNotInDOM();
+});
+test('error message should disappear upon succesful api call', async () => {
+  const user = userEvent.setup();
+  const userMessage = 'Hello, Xpert!';
+
+  const errorState = {
+    learningAssistant: {
+      currentMessage: '',
+      messageList: [],
+      apiIsLoading: false,
+      apiError: true,
+    },
+  };
+  render(<Xpert courseId={courseId} />, { preloadedState: errorState });
+
+  await user.click(screen.getByRole('button', { name: 'Have a question?' }));
+
+  // assert that error message exists
+  expect(screen.queryByText('Please try again by sending another question.')).toBeInTheDocument();
+
+  // submit text, assert that error message disappears
+  const input = screen.getByRole('textbox');
+  await user.type(input, userMessage);
+  await user.click(screen.getByTestId('submit-button'));
+  expect(screen.queryByText('Please try again by sending another question.')).not.toBeInTheDocument();
+});
+test('error message should disappear when dismissed', async () => {
+  const user = userEvent.setup();
+
+  const errorState = {
+    learningAssistant: {
+      currentMessage: '',
+      messageList: [],
+      apiIsLoading: false,
+      apiError: true,
+    },
+  };
+  render(<Xpert courseId={courseId} />, { preloadedState: errorState });
+
+  await user.click(screen.getByRole('button', { name: 'Have a question?' }));
+
+  // assert that error message exists
+  expect(screen.queryByText('Please try again by sending another question.')).toBeInTheDocument();
+
+  // dismiss alert, assert that error message disappears
+  await user.click(screen.getByText('Dismiss'));
+  expect(screen.queryByText('Please try again by sending another question.')).not.toBeInTheDocument();
+});
+test('error message should disappear when messages cleared', async () => {
+  const user = userEvent.setup();
+
+  const errorState = {
+    learningAssistant: {
+      currentMessage: '',
+      messageList: [],
+      apiIsLoading: false,
+      apiError: true,
+    },
+  };
+  render(<Xpert courseId={courseId} />, { preloadedState: errorState });
+
+  await user.click(screen.getByRole('button', { name: 'Have a question?' }));
+
+  // assert that error message exists
+  expect(screen.queryByText('Please try again by sending another question.')).toBeInTheDocument();
+
+  // clear messages, assert that error message disappears
+  await user.click(screen.getByText('Clear'));
+  expect(screen.queryByText('Please try again by sending another question.')).not.toBeInTheDocument();
 });


### PR DESCRIPTION
## [MST-2065](https://2u-internal.atlassian.net/browse/MST-2065)

If the completion API endpoint returns with a non 200 response, we should show an error message to the user. The error message should clear:

- if the user submits a new message
- if a user hits the "clear" button

![Screenshot 2023-08-23 at 4 01 35 PM](https://github.com/edx/frontend-lib-learning-assistant/assets/46360176/2f5cb1bd-230f-4fae-8b23-3879964598cd)
