### PR TITLE
fix: prevent icon button from moving on click

### DIFF
--- a/src/components/ToggleXpertButton/index.jsx
+++ b/src/components/ToggleXpertButton/index.jsx
@@ -37,10 +37,10 @@ const ToggleXpert = ({ isOpen, setIsOpen, courseId }) => {
             alt="dismiss"
             onClick={handleDismiss}
             variant="light"
-            className="dismiss-button mx-2 mt-2 bg-gray"
+            className="dismiss-button mx-2 mt-1 bg-gray"
             size="sm"
           />
-          <div className="action-message open-negative-margin px-3 py-3 my-2">
+          <div className="action-message open-negative-margin p-3 mb-5.5">
             <span>
               Hi there! 👋 I&apos;m Xpert,
               an AI-powered assistant from edX who can help you with questions about this course.

--- a/src/components/ToggleXpertButton/index.scss
+++ b/src/components/ToggleXpertButton/index.scss
@@ -7,6 +7,7 @@
 
     &.button-icon {
         background-color: variables.$dark-green;
+        position: inherit;
     }
 
     &.open {


### PR DESCRIPTION
Without the `position-fixed` class name, the toggle icon would move when clicked. This change prevents the icon from moving as it is clicked.