### PR TITLE
fix: user input should have focus

### DIFF
--- a/src/components/MessageForm/index.jsx
+++ b/src/components/MessageForm/index.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { Button, Form, Icon } from '@edx/paragon';
@@ -12,9 +12,16 @@ import {
   updateCurrentMessage,
 } from '../../data/thunks';
 
-const MessageForm = ({ courseId }) => {
-  const { apiIsLoading, currentMessage } = useSelector(state => state.learningAssistant);
+const MessageForm = ({ courseId, shouldAutofocus }) => {
+  const { apiIsLoading, currentMessage, apiError } = useSelector(state => state.learningAssistant);
   const dispatch = useDispatch();
+  const inputRef = useRef();
+
+  useEffect(() => {
+    if (inputRef.current && !apiError && !apiIsLoading && shouldAutofocus) {
+      inputRef.current.focus();
+    }
+  }, [apiError, apiIsLoading, shouldAutofocus]);
 
   const handleSubmitMessage = (event) => {
     event.preventDefault();
@@ -51,6 +58,7 @@ const MessageForm = ({ courseId }) => {
           onChange={handleUpdateCurrentMessage}
           trailingElement={getSubmitButton()}
           value={currentMessage}
+          ref={inputRef}
         />
       </Form.Group>
     </Form>
@@ -59,6 +67,11 @@ const MessageForm = ({ courseId }) => {
 
 MessageForm.propTypes = {
   courseId: PropTypes.string.isRequired,
+  shouldAutofocus: PropTypes.bool,
+};
+
+MessageForm.defaultProps = {
+  shouldAutofocus: false,
 };
 
 export default MessageForm;

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -106,7 +106,7 @@ const Sidebar = ({
           </div>
         )
       }
-      <MessageForm courseId={courseId} />
+      <MessageForm courseId={courseId} shouldAutofocus />
       <div className="d-flex justify-content-start">
         <Button
           className="clear mx-2 mb-2 border-0"

--- a/src/widgets/Xpert.test.jsx
+++ b/src/widgets/Xpert.test.jsx
@@ -75,6 +75,9 @@ test('clicking the toggle button opens the sidebar', async () => {
   expect(screen.getByRole('button', { name: 'submit' })).toBeVisible();
   expect(screen.getByTestId('close-button')).toBeVisible();
   expect(screen.getByRole('button', { name: 'clear' })).toBeVisible();
+
+  // assert that text input has focus
+  expect(screen.getByRole('textbox')).toHaveFocus();
 });
 test('submitted text appears as message in the sidebar', async () => {
   const user = userEvent.setup();


### PR DESCRIPTION
## [MST-2095](https://2u-internal.atlassian.net/browse/MST-2095)

Previously, the text input field would not be in focus after a response was returned. For accessibility and ease of use, the input field should be in focus after a response has been returned, and if there is not an API error. 

Updated behavior:
https://github.com/edx/frontend-lib-learning-assistant/assets/46360176/3d91ea78-075d-47ca-84ab-2e132b9fcf8d

