### PR TITLE
Conditionally render toggle button and action message only when the sidebar is closed.

### DIFF
--- a/src/components/ToggleXpertButton/index.jsx
+++ b/src/components/ToggleXpertButton/index.jsx
@@ -28,6 +28,7 @@ const ToggleXpert = ({ isOpen, setIsOpen, courseId }) => {
   };
 
   return (
+    (!isOpen && (
     <div className="toggle closed d-flex flex-column position-fixed justify-content-end align-items-end mx-3 border-0">
       {!hasDismissed && (
         <div className="d-flex justify-content-end flex-row" data-testid="action-message">
@@ -57,6 +58,7 @@ const ToggleXpert = ({ isOpen, setIsOpen, courseId }) => {
         <XpertLogo />
       </Button>
     </div>
+    ))
   );
 };
 

--- a/src/widgets/Xpert.test.jsx
+++ b/src/widgets/Xpert.test.jsx
@@ -182,15 +182,14 @@ test('clicking the close button closes the sidebar', async () => {
   // assert that UI elements in the sidebar are not in the DOM
   assertSidebarElementsNotInDOM();
 });
-test('clicking the toggle button closes the sidebar', async () => {
+test('toggle elements do not appear when sidebar is open', async () => {
   const user = userEvent.setup();
   render(<Xpert courseId={courseId} />, { preloadedState: initialState });
 
   await user.click(screen.queryByTestId('toggle-button'));
-  await user.click(screen.getByTestId('toggle-button'));
 
-  // assert that UI elements in the sidebar are not in the DOM
-  assertSidebarElementsNotInDOM();
+  expect(screen.queryByTestId('toggle-button')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('action-message')).not.toBeInTheDocument();
 });
 test('error message should disappear upon succesful api call', async () => {
   const user = userEvent.setup();


### PR DESCRIPTION
### Description

This pull request fixes a bug where the toggle button and action message remain in the DOM when the sidebar is open. Typically, they aren't visible because they're obfuscated by the open sidebar. However, on smaller screen sizes, or when the window is made smaller, the toggle button and action message are visible behind the sidebar. This commit conditionally renders the toggle button and action message only when the sidebar is closed.

JIRA: [MST-2092](https://2u-internal.atlassian.net/browse/MST-2092) (private)

### Demo

**Before**

https://github.com/edx/frontend-lib-learning-assistant/assets/11871801/886d210f-a3cf-48b2-af85-847e8eea147d

**After**

https://github.com/edx/frontend-lib-learning-assistant/assets/11871801/938880f1-a28e-4680-9167-41e307f73fad
