### PR TITLE
Add additional Segment eventing for rendering toggle and closing call-to-action.

### DIFF
--- a/src/components/ToggleXpertButton/index.jsx
+++ b/src/components/ToggleXpertButton/index.jsx
@@ -30,7 +30,16 @@ const ToggleXpert = ({
     event.preventDefault();
     event.stopPropagation();
     setHasDismissed(true);
+    sendTrackEvent('edx.ui.lms.learning_assistant.dismiss_action_message', {
+      course_id: courseId,
+    });
   };
+
+  // TODO: Remove this Segment alert. This has been added purely to diagnose whether
+  //       usage issues are as a result of the Xpert toggle button not appearing.
+  sendTrackEvent('edx.ui.lms.learning_assistant.render_toggle_button', {
+    course_id: courseId,
+  });
 
   return (
     (!isOpen && (


### PR DESCRIPTION
### Description

In order to diagnose low usage rates, we're temporarily adding Segment events for rendering the toggle Xpert button and for closing the call-to-action message. This will help us determine whether the Xpert toggle button is being successfully rendered and whether the Xpert is being ignored by tracking whether learners close the call-to-action message at a high rate.

At a minimum, we expect to remove the Segment event for rendering the toggle Xpert button, because this will be a very noisy Segment event. We plan to leave it in for a few days just to accumulate data. We will evaluate whether to keep the call-to-action dismissal Segment event based on the data.

Note: This commit probably should be a `temp` commit, but that won't trigger a semantic release, so `feat` seems like the most appropriate to use here.

**Jira**: None.