### PR TITLE
fix: remove Segment event for rendering toggle

### DIFF
--- a/src/components/ToggleXpertButton/index.jsx
+++ b/src/components/ToggleXpertButton/index.jsx
@@ -35,12 +35,6 @@ const ToggleXpert = ({
     });
   };
 
-  // TODO: Remove this Segment alert. This has been added purely to diagnose whether
-  //       usage issues are as a result of the Xpert toggle button not appearing.
-  sendTrackEvent('edx.ui.lms.learning_assistant.render_toggle_button', {
-    course_id: courseId,
-  });
-
   return (
     (!isOpen && (
     <div className={


### PR DESCRIPTION
### Description

In #25, we added a Segment event for rendering the Xpert toggle button. This results in test failures in the downstream frontend-app-learning. These failures are likely due to the fact that the frontend-app-learning test is unable to mock out the frontend-platform module installed in this library. This results in failures, because the analytics service is not configured in the frontend-app-learning tests. In light of that, we've decided to move the render Segment event to the Chat component in the frontend-app-learning, which wraps the Xpert component.

**Jira:** None