### PR TITLE
feat: persist cta dismissal and change survey trigger

### DIFF
--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -68,9 +68,9 @@ const Sidebar = ({
   const handleClick = () => {
     setIsOpen(false);
 
-    // check to see if hotjar is available, then trigger hotjar event
+    // check to see if hotjar is available, then trigger hotjar event if user has sent and received a message
     const hasWindow = typeof window !== 'undefined';
-    if (hasWindow && window.hj) {
+    if (hasWindow && window.hj && messageList.length >= 2) {
       window.hj('event', 'ocm_learning_assistant_chat_closed');
     }
   };

--- a/src/components/ToggleXpertButton/index.jsx
+++ b/src/components/ToggleXpertButton/index.jsx
@@ -51,6 +51,7 @@ const ToggleXpert = ({
     event.preventDefault();
     event.stopPropagation();
     setHasDismissed(true);
+    localStorage.setItem('dismissedLearningAssistantCallToAction', 'true');
     sendTrackEvent('edx.ui.lms.learning_assistant.dismiss_action_message', {
       course_id: courseId,
     });
@@ -94,7 +95,7 @@ const ToggleXpert = ({
           ${contentToolsEnabled ? 'chat-content-tools-margin' : ''}`
         }
       >
-        {!hasDismissed && (
+        {(!localStorage.getItem('dismissedLearningAssistantCallToAction') && !hasDismissed) && (
           <div
             className="d-flex justify-content-end flex-row "
             data-testid="action-message"

--- a/src/widgets/Xpert.test.jsx
+++ b/src/widgets/Xpert.test.jsx
@@ -39,6 +39,7 @@ const assertSidebarElementsNotInDOM = () => {
 beforeEach(() => {
   const responseMessage = createRandomResponseForTesting();
   jest.spyOn(api, 'default').mockResolvedValue(responseMessage);
+  window.localStorage.clear();
 });
 
 test('initial load displays correct elements', () => {
@@ -62,6 +63,10 @@ test('clicking the call to action dismiss button removes the message', async () 
   await user.click(screen.getByRole('button', { name: 'dismiss' }));
   expect(screen.queryByTestId('toggle-button')).toBeVisible();
   expect(screen.queryByTestId('action-message')).not.toBeInTheDocument();
+
+  // re-render exam, button to dismiss cta should not be there
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} />, { preloadedState: initialState });
+  expect(screen.queryByRole('button', { name: 'dismiss' })).not.toBeInTheDocument();
 });
 test('clicking the call to action opens the sidebar', async () => {
   const user = userEvent.setup();


### PR DESCRIPTION
## [MST-2156](https://2u-internal.atlassian.net/browse/MST-2156)

If a user dismisses the CTA, that dismissal should be persisted. Additionally, we would only like to trigger the survey after a user has interacted with the learning assistant, so the hotjar event should only be triggered after a user sends and receives a message.