### PR TITLE
fix: modal popup should be grouped with toggle button

### DIFF
--- a/src/components/ToggleXpertButton/index.jsx
+++ b/src/components/ToggleXpertButton/index.jsx
@@ -72,47 +72,48 @@ const ToggleXpert = ({
     && (localStorage.getItem('completedLearningAssistantTour') || !isModalOpen)
   );
 
+  const chatMargin = contentToolsEnabled ? 'mb-5' : 'mb-3';
+
   return (
     (!isOpen && (
-    <>
-      <div
-        className="position-fixed learning-assistant-popup-modal"
-      >
-        <ModalPopup
-          hasArrow
-          placement="left"
-          positionRef={target}
-          isOpen={isModalOpen && !localStorage.getItem('completedLearningAssistantTour')}
-          onClose={handleModalClose}
-        >
-          <div
-            className="bg-white p-3 rounded shadow border"
-            style={{ textAlign: 'start' }}
-          >
-            <p data-testid="modal-message">
-              Xpert is a new part of your learning experience.<br />
-              You can ask questions and get tutoring help during your course.
-            </p>
-            <div className="d-flex justify-content-start" style={{ gap: '10px' }}>
-              <ModalCloseButton variant="outline-primary" data-testid="close-button">Close</ModalCloseButton>
-              <Button
-                variant="primary"
-                className="mie-2"
-                onClick={handleClick}
-                data-testid="check-button"
-              >
-                Check it out
-              </Button>
-            </div>
-          </div>
-        </ModalPopup>
-      </div>
       <div
         className={
           `toggle position-fixed closed d-flex flex-column justify-content-end align-items-end mx-3 border-0 
-          ${contentToolsEnabled ? 'chat-content-tools-margin' : ''}`
+           ${chatMargin}`
         }
       >
+        <div
+          className="position-fixed learning-assistant-popup-modal mb-7"
+        >
+          <ModalPopup
+            hasArrow
+            placement="left"
+            positionRef={target}
+            isOpen={isModalOpen && !localStorage.getItem('completedLearningAssistantTour')}
+            onClose={handleModalClose}
+          >
+            <div
+              className={`bg-white p-3 rounded shadow border ${chatMargin}`}
+              style={{ textAlign: 'start' }}
+            >
+              <p data-testid="modal-message">
+                Xpert is a new part of your learning experience.<br />
+                You can ask questions and get tutoring help during your course.
+              </p>
+              <div className="d-flex justify-content-start" style={{ gap: '10px' }}>
+                <ModalCloseButton variant="outline-primary" data-testid="close-button">Close</ModalCloseButton>
+                <Button
+                  variant="primary"
+                  className="mie-2"
+                  onClick={handleClick}
+                  data-testid="check-button"
+                >
+                  Check it out
+                </Button>
+              </div>
+            </div>
+          </ModalPopup>
+        </div>
         { shouldDisplayCTA && (
           <div
             className="d-flex justify-content-end flex-row "
@@ -153,7 +154,6 @@ const ToggleXpert = ({
           <XpertLogo />
         </Button>
       </div>
-    </>
     ))
   );
 };

--- a/src/components/ToggleXpertButton/index.scss
+++ b/src/components/ToggleXpertButton/index.scss
@@ -44,11 +44,6 @@
     height: 1.5rem !important;
 }
 
-// this class is used to shift the display of the toggle to account for the display of content tools
-.chat-content-tools-margin {
-    margin-bottom: 2rem;
-}
-
 .learning-assistant-popup-modal {
     width: 100%;
 }


### PR DESCRIPTION
Because the popup modal did not share the same parent div as our toggle component, the position of the modal popup and the toggle would differ as the courseware page loaded. 

As part of this PR I also fixed some margins for both the toggle and the popup to ensure that they do not overlay over the course tools (i.e. calculator and notes). 

Before:
![Screenshot 2024-01-24 at 2 35 02 PM](https://github.com/edx/frontend-lib-learning-assistant/assets/46360176/d08c56a2-0512-4457-986f-c551ce82d47b)

After:
![Screenshot 2024-01-24 at 2 27 03 PM](https://github.com/edx/frontend-lib-learning-assistant/assets/46360176/7d83e30f-0dbc-4327-ab1e-3cbe8c5b5709)

![Screenshot 2024-01-24 at 2 26 48 PM](https://github.com/edx/frontend-lib-learning-assistant/assets/46360176/1b9e1608-f252-4e8d-9d92-13b7030c97a9)

