### PR TITLE
feat: use backend GET endpoint to determine whether to show Learning Assistant

### DIFF
--- a/src/data/api.js
+++ b/src/data/api.js
@@ -19,4 +19,12 @@ async function fetchChatResponse(courseId, messageList, unitId) {
   return data;
 }
 
+async function fetchLearningAssistantEnabled(courseId) {
+  const url = new URL(`${getConfig().CHAT_RESPONSE_URL}/${courseId}/enabled`);
+
+  const { data } = await getAuthenticatedHttpClient().get(url.href);
+  return data;
+}
+
 export default fetchChatResponse;
+export { fetchLearningAssistantEnabled };

--- a/src/data/slice.js
+++ b/src/data/slice.js
@@ -12,6 +12,7 @@ export const learningAssistantSlice = createSlice({
     conversationId: uuidv4(),
     disclosureAcknowledged: false,
     sidebarIsOpen: false,
+    isEnabled: false,
   },
   reducers: {
     setCurrentMessage: (state, { payload }) => {
@@ -43,6 +44,9 @@ export const learningAssistantSlice = createSlice({
     setSidebarIsOpen: (state, { payload }) => {
       state.sidebarIsOpen = payload;
     },
+    setIsEnabled: (state, { payload }) => {
+      state.isEnabled = payload;
+    },
   },
 });
 
@@ -56,6 +60,7 @@ export const {
   resetApiError,
   setDisclosureAcknowledged,
   setSidebarIsOpen,
+  setIsEnabled,
 } = learningAssistantSlice.actions;
 
 export const {

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -1,6 +1,6 @@
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import fetchChatResponse from './api';
+import fetchChatResponse, { fetchLearningAssistantEnabled } from './api';
 import {
   setCurrentMessage,
   clearCurrentMessage,
@@ -11,6 +11,7 @@ import {
   resetApiError,
   setDisclosureAcknowledged,
   setSidebarIsOpen,
+  setIsEnabled,
 } from './slice';
 
 export function addChatMessage(role, content, courseId) {
@@ -87,5 +88,16 @@ export function acknowledgeDisclosure(isDisclosureAcknowledged) {
 export function updateSidebarIsOpen(isOpen) {
   return (dispatch) => {
     dispatch(setSidebarIsOpen(isOpen));
+  };
+}
+
+export function getIsEnabled(courseId) {
+  return async (dispatch) => {
+    try {
+      const data = await fetchLearningAssistantEnabled(courseId);
+      dispatch(setIsEnabled(data.enabled));
+    } catch (error) {
+      dispatch(setApiError());
+    }
   };
 }

--- a/src/widgets/Xpert.jsx
+++ b/src/widgets/Xpert.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { updateSidebarIsOpen } from '../data/thunks';
+import { updateSidebarIsOpen, getIsEnabled } from '../data/thunks';
 import ToggleXpert from '../components/ToggleXpertButton';
 import Sidebar from '../components/Sidebar';
 
@@ -8,13 +9,19 @@ const Xpert = ({ courseId, contentToolsEnabled, unitId }) => {
   const dispatch = useDispatch();
 
   const {
+    isEnabled,
     sidebarIsOpen,
   } = useSelector(state => state.learningAssistant);
 
   const setSidebarIsOpen = (isOpen) => {
     dispatch(updateSidebarIsOpen(isOpen));
   };
-  return (
+
+  useEffect(() => {
+    dispatch(getIsEnabled(courseId));
+  }, [dispatch, courseId]);
+
+  return isEnabled ? (
     <div>
       <ToggleXpert
         courseId={courseId}
@@ -29,7 +36,7 @@ const Xpert = ({ courseId, contentToolsEnabled, unitId }) => {
         unitId={unitId}
       />
     </div>
-  );
+  ) : null;
 };
 
 Xpert.propTypes = {


### PR DESCRIPTION
### Description

**Jira**: [COSMO-161](https://2u-internal.atlassian.net/browse/COSMO-161)

**Prerequisite**: https://github.com/edx/learning-assistant/pull/63 must be merged and deployed before this pull request is merged and deployed.

This commit uses a new GET endpoint published on the Learning Assistant backend to determine whether the Learning Assistant feature is enabled. If the features is not enabled, the Learning Assistant is not rendered, and vice-versa.

This is an alternative to using the `edx-platform` Courseware API to determine whether the feature is enabled. The reason this decision was made was so as not to introduce 2U-specific code into the platform in the form of calls to the `learning-assistant` plugin and it's models and APIs. This allows the Learning Assistant frontend to encapsulate calls to the backend instead.

Please see https://github.com/edx/learning-assistant/pull/63 for more details.