### PR TITLE
feat: remove scrollbar css styling

### DIFF
--- a/src/components/ChatBox/ChatBox.scss
+++ b/src/components/ChatBox/ChatBox.scss
@@ -1,6 +1,5 @@
 .scroller {
   overflow-y: scroll;
-  scrollbar-color: rebeccapurple green;
   scrollbar-width: thin;
   width: 100%;
   opacity: 1;


### PR DESCRIPTION
I noticed that the scrollbar on stage and prod was now green, which was not the case previously. I discovered that we had some custom css styling on the scrollbar, that was now appearing. 

Before:
![Screenshot 2024-02-13 at 9 52 41 AM](https://github.com/edx/frontend-lib-learning-assistant/assets/46360176/34ea3af6-62fa-4343-b1cd-928874a3b26d)

After:
![Screenshot 2024-02-13 at 9 52 52 AM](https://github.com/edx/frontend-lib-learning-assistant/assets/46360176/04e6a677-cf96-4c67-a41e-78dc9690cd17)
