### PR TITLE
feat: xpert should have z-index priority

### DIFF
--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -5,6 +5,7 @@
   top: 0;
   bottom: 0;
   background-color: white;
+  z-index: 9999;
 
   width: 30%;
   right: 0;

--- a/src/components/ToggleXpertButton/index.scss
+++ b/src/components/ToggleXpertButton/index.scss
@@ -4,6 +4,7 @@
     border-radius: 2rem;
     bottom: 1rem;
     height: 3rem;
+    z-index: 9999;
 
     &.button-icon {
         background-color: variables.$dark-green;


### PR DESCRIPTION
Because the new sidebar components have been released to prod, and in rendering have a higher z-index, we need to manually set the z-index for Xpert to ensure that it overlays on top of other components visible in the courseware. 

Before:
<img width="1408" alt="Screenshot 2024-02-20 at 8 37 47 AM" src="https://github.com/edx/frontend-lib-learning-assistant/assets/46360176/773f1d43-3f9d-4a07-8a84-4d10d17b6586">

After:
<img width="762" alt="Screenshot 2024-02-20 at 9 40 35 AM" src="https://github.com/edx/frontend-lib-learning-assistant/assets/46360176/5ab349e8-9469-4ac9-b511-4c43706fbfa7">
