### PR TITLE
fix: update toggle button width

### DIFF
--- a/src/components/ToggleXpertButton/index.scss
+++ b/src/components/ToggleXpertButton/index.scss
@@ -9,6 +9,7 @@
     &.button-icon {
         background-color: variables.$dark-green;
         position: relative;
+        width: 125px;
     }
 
     &.open {


### PR DESCRIPTION
## [COSMO-203](https://2u-internal.atlassian.net/browse/COSMO-203)

The Xpert toggle button was appearing with a larger width than intended in safari. No width was specified (either by percentage or pixel), so browsers likely calculated/inferred the width for the toggle element differently. 

This change specifies a pixel width, so that the button appears the same across browsers.

Before:
![Screenshot 2024-03-18 at 10 53 10 AM](https://github.com/edx/frontend-lib-learning-assistant/assets/46360176/8ce9efaa-636a-478e-a390-384655463b00)

After:
![Screenshot 2024-03-18 at 10 53 23 AM](https://github.com/edx/frontend-lib-learning-assistant/assets/46360176/eccb90e4-fe69-4cd8-a86e-8c31fde6eb9f)

