### PR TITLE
fix: rounded border on widget

### DIFF
--- a/src/components/ToggleXpertButton/index.scss
+++ b/src/components/ToggleXpertButton/index.scss
@@ -1,10 +1,13 @@
 @use '../../utils/variables';
 
 .toggle {
-    border-radius: 2rem;
     bottom: 1rem;
     height: 3rem;
     z-index: 9999;
+
+    .btn {
+        border-radius: 2rem;
+    }
 
     &.button-icon {
         background-color: variables.$dark-green;


### PR DESCRIPTION
This was getting overridden by the paragon .btn border style

I wasn't able to reproduce the issue locally but I think the level of specificity wasn't high enough originally.