### PR TITLE
fix: replace set-output github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       uses: codecov/codecov-action@v4
     - name: Extract branch name
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
       id: extract_branch
     - name: Preview semantic-release version
       env:


### PR DESCRIPTION
## Description
- `set-output` has been deprecated by GitHub and it is suggested to be replaced by GitHub.