### PR TITLE
fix: modify optimizely tracking calls

### DIFF
--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -1,7 +1,7 @@
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 
-import { trackChatBotMessageOptimizely } from '../utils/optimizelyExperiment';
+import trackChatBotMessageOptimizely from '../utils/optimizelyExperiment';
 import fetchChatResponse, { fetchLearningAssistantEnabled } from './api';
 import {
   setCurrentMessage,
@@ -60,7 +60,7 @@ export function getChatResponse(courseId, unitId, promptExperimentVariationKey =
     dispatch(setApiIsLoading(true));
     try {
       if (promptExperimentVariationKey) {
-        trackChatBotMessageOptimizely(userId);
+        trackChatBotMessageOptimizely(userId.toString());
       }
       const customQueryParams = promptExperimentVariationKey ? { responseVariation: promptExperimentVariationKey } : {};
       const message = await fetchChatResponse(courseId, messageList, unitId, customQueryParams);

--- a/src/utils/optimizelyExperiment.js
+++ b/src/utils/optimizelyExperiment.js
@@ -1,16 +1,8 @@
 import { getOptimizely } from '../data/optimizely';
 
-const trackChatBotLaunchOptimizely = (userId, userAttributes = {}) => {
-  const optimizelyInstance = getOptimizely();
-  optimizelyInstance.track('learning_assistant_chat_click', userId, userAttributes);
-};
-
 const trackChatBotMessageOptimizely = (userId, userAttributes = {}) => {
   const optimizelyInstance = getOptimizely();
   optimizelyInstance.track('learning_assistant_chat_message', userId, userAttributes);
 };
 
-export {
-  trackChatBotLaunchOptimizely,
-  trackChatBotMessageOptimizely,
-};
+export default trackChatBotMessageOptimizely;


### PR DESCRIPTION
Optimizely always expects the userId to be passed as a string. Because the user ID is currently being passed as an integer, calls to the `track` function are failing on stage right now.