### PR TITLE
fix: Removed autoupdate due to constant updates

### DIFF
--- a/src/experiments/experimentHooks.js
+++ b/src/experiments/experimentHooks.js
@@ -9,7 +9,6 @@ export function usePromptExperimentDecision() {
 
   const [decision] = useDecision(
     OPTIMIZELY_PROMPT_EXPERIMENT_KEY,
-    { autoUpdate: true }, // This should make the decision reactive to changes on the experiment dashboard.
     { overrideUserId: userId.toString() }, // This override is just to make sure the userId is up to date.
   );
 


### PR DESCRIPTION
[COSMO-400 🔒](https://2u-internal.atlassian.net/browse/COSMO-400)

# Description
Based on our observation, it seems that using `autoUpdate` option in Optimizely's `useDecision()` hook causes Optimizely to be updated in every component update. This was removed as it was not strictly required.