### PR TITLE
Reduced specificity on Redux rependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "react-redux": "7.2.9",
         "react-router": "5.2.1 || ^6.0.0",
         "react-router-dom": "5.3.0 || ^6.0.0",
-        "redux": "4.1.2",
+        "redux": "4^",
         "regenerator-runtime": "0.13.11"
       }
     },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-redux": "7.2.9",
     "react-router": "5.2.1 || ^6.0.0",
     "react-router-dom": "5.3.0 || ^6.0.0",
-    "redux": "4.1.2",
+    "redux": "4^",
     "regenerator-runtime": "0.13.11"
   },
   "devDependencies": {


### PR DESCRIPTION
This update is related with issue https://github.com/openedx/frontend-app-learning/issues/1482: Reducing specificity in redux peer dependency allows more flexibility on `fontend-app-learning` to update it.