### PR TITLE
fix: Fixed redux npm package version reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "react-redux": "7.2.9",
         "react-router": "5.2.1 || ^6.0.0",
         "react-router-dom": "5.3.0 || ^6.0.0",
-        "redux": "4^",
+        "redux": "^4",
         "regenerator-runtime": "0.13.11"
       }
     },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-redux": "7.2.9",
     "react-router": "5.2.1 || ^6.0.0",
     "react-router-dom": "5.3.0 || ^6.0.0",
-    "redux": "4^",
+    "redux": "^4",
     "regenerator-runtime": "0.13.11"
   },
   "devDependencies": {


### PR DESCRIPTION
There was a typo on an update for the `redux` npm package dependency. I've used `4^` instead of `^4`.