### PR TITLE
feat: introduce new prop for upgrade eligibility

### DIFF
--- a/src/widgets/Xpert.jsx
+++ b/src/widgets/Xpert.jsx
@@ -7,7 +7,12 @@ import ToggleXpert from '../components/ToggleXpertButton';
 import Sidebar from '../components/Sidebar';
 import { ExperimentsProvider } from '../experiments';
 
-const Xpert = ({ courseId, contentToolsEnabled, unitId }) => {
+const Xpert = ({
+  courseId,
+  contentToolsEnabled,
+  unitId,
+  isUpgradeEligible, // eslint-disable-line no-unused-vars
+}) => {
   const dispatch = useDispatch();
 
   const {
@@ -58,6 +63,7 @@ Xpert.propTypes = {
   courseId: PropTypes.string.isRequired,
   contentToolsEnabled: PropTypes.bool.isRequired,
   unitId: PropTypes.string.isRequired,
+  isUpgradeEligible: PropTypes.bool.isRequired,
 };
 
 export default Xpert;


### PR DESCRIPTION
As we introduce the audit trial experience, the Xpert component must be aware of whether or not a learner is eligible for upgrade. This PR introduces a new prop which can then be used in child components to determine whether or not to display trial language/UX.