### PR TITLE
feat: display upgrade panel when audit trial is expired

### DIFF
--- a/src/components/Disclosure/__snapshots__/index.test.jsx.snap
+++ b/src/components/Disclosure/__snapshots__/index.test.jsx.snap
@@ -119,7 +119,7 @@ exports[`<TrialDisclosure /> When trial upgrade being shown should match snapsho
             </small>
           </div>
           <a
-            class="trial-upgrade mt-3 btn btn-primary btn-block"
+            class="trial-upgrade mt-3 btn btn-brand btn-block"
             data-testid="upgrade-cta"
             href="https://upgrade.edx/course/test"
           >

--- a/src/components/Disclosure/index.jsx
+++ b/src/components/Disclosure/index.jsx
@@ -1,20 +1,20 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Hyperlink, Icon, Button } from '@openedx/paragon';
+import { Hyperlink, Icon } from '@openedx/paragon';
 import { QuestionAnswerOutline, LightbulbCircle, AutoAwesome } from '@openedx/paragon/icons';
 import { ensureConfig, getConfig } from '@edx/frontend-platform/config';
-import { useCourseUpgrade, useTrackEvent } from '../../hooks';
+
+import UpgradeButton from '../UpgradeButton';
+import { useCourseUpgrade } from '../../hooks';
 
 import './Disclosure.scss';
 
 ensureConfig(['PRIVACY_POLICY_URL']);
 
 const Disclosure = ({ children }) => {
-  const { upgradeable, upgradeUrl, auditTrialLengthDays } = useCourseUpgrade();
-  const { track } = useTrackEvent();
+  const { upgradeable, auditTrialLengthDays } = useCourseUpgrade();
 
-  const handleClick = () => track('edx.ui.lms.learning_assistant.disclosure_upgrade_click');
   const freeDays = auditTrialLengthDays === 1 ? '1 day' : `${auditTrialLengthDays} days`;
 
   return (
@@ -49,15 +49,7 @@ const Disclosure = ({ children }) => {
                   Free for {freeDays}, then upgrade course for full access to Xpert features.
                 </small>
               </div>
-              <Button
-                onClick={handleClick}
-                href={upgradeUrl}
-                className="trial-upgrade mt-3"
-                block
-                data-testid="upgrade-cta"
-              >
-                Upgrade now
-              </Button>
+              <UpgradeButton trackingEventName="edx.ui.lms.learning_assistant.disclosure_upgrade_click" />
             </div>
           </div>
         ) : null}

--- a/src/components/Disclosure/index.test.jsx
+++ b/src/components/Disclosure/index.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { render } from '../../utils/utils.test';
-import { useCourseUpgrade, useTrackEvent } from '../../hooks';
+import { useCourseUpgrade } from '../../hooks';
 
 import TrialDisclosure from '.';
 
@@ -53,15 +53,12 @@ describe('<TrialDisclosure />', () => {
   });
 
   describe('When trial upgrade being shown', () => {
-    const mockedTrackEvent = jest.fn();
-
     beforeEach(() => {
       useCourseUpgrade.mockReturnValue({
         upgradeable: true,
         upgradeUrl: mockedUpgradeUrl,
         auditTrialLengthDays: mockedAuditTrialDays,
       });
-      useTrackEvent.mockReturnValue({ track: mockedTrackEvent });
       ({ container } = render(<TrialDisclosure showTrial><span>Children</span></TrialDisclosure>));
     });
 
@@ -76,16 +73,6 @@ describe('<TrialDisclosure />', () => {
 
       expect(upgradeCta).toBeInTheDocument();
       expect(upgradeCta).toHaveAttribute('href', mockedUpgradeUrl);
-    });
-
-    it('should call the track event on click', () => {
-      const upgradeCta = screen.queryByTestId('upgrade-cta');
-
-      expect(mockedTrackEvent).not.toHaveBeenCalled();
-
-      fireEvent.click(upgradeCta);
-
-      expect(mockedTrackEvent).toHaveBeenCalledWith('edx.ui.lms.learning_assistant.disclosure_upgrade_click');
     });
 
     it('should match snapshot', () => {

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -7,11 +7,13 @@ import {
 } from '@openedx/paragon';
 import { Close } from '@openedx/paragon/icons';
 
+import { useCourseUpgrade } from '../../hooks';
 import showSurvey from '../../utils/surveyMonkey';
 
 import APIError from '../APIError';
 import ChatBox from '../ChatBox';
 import Disclosure from '../Disclosure';
+import UpgradePanel from '../UpgradePanel';
 import MessageForm from '../MessageForm';
 import { ReactComponent as XpertLogo } from '../../assets/xpert-logo.svg';
 import './Sidebar.scss';
@@ -27,6 +29,9 @@ const Sidebar = ({
     disclosureAcknowledged,
     messageList,
   } = useSelector(state => state.learningAssistant);
+
+  const { upgradeable, auditTrialExpired } = useCourseUpgrade();
+
   const chatboxContainerRef = useRef(null);
 
   // this use effect is intended to scroll to the bottom of the chat window, in the case
@@ -97,6 +102,15 @@ const Sidebar = ({
     </div>
   );
 
+  const getPanel = () => {
+    const showUpgrade = upgradeable && auditTrialExpired;
+
+    if (showUpgrade) {
+      return <UpgradePanel />;
+    }
+    return (disclosureAcknowledged ? (getSidebar()) : (<Disclosure>{getMessageForm()}</Disclosure>));
+  };
+
   return (
     isOpen && (
       <div
@@ -114,7 +128,7 @@ const Sidebar = ({
           invertColors
           data-testid="close-button"
         />
-        {disclosureAcknowledged ? (getSidebar()) : (<Disclosure>{getMessageForm()}</Disclosure>)}
+        {getPanel()}
       </div>
     )
   );

--- a/src/components/Sidebar/index.test.jsx
+++ b/src/components/Sidebar/index.test.jsx
@@ -5,6 +5,7 @@ import { usePromptExperimentDecision } from '../../experiments';
 import { render as renderComponent } from '../../utils/utils.test';
 import { initialState } from '../../data/slice';
 import showSurvey from '../../utils/surveyMonkey';
+import { useCourseUpgrade, useTrackEvent } from '../../hooks';
 
 import Sidebar from '.';
 
@@ -31,6 +32,11 @@ jest.mock('react-redux', () => ({
 
 jest.mock('../../experiments', () => ({
   usePromptExperimentDecision: jest.fn(),
+}));
+
+jest.mock('../../hooks', () => ({
+  useCourseUpgrade: jest.fn(),
+  useTrackEvent: jest.fn(),
 }));
 
 const defaultProps = {
@@ -63,6 +69,8 @@ const render = async (props = {}, sliceState = {}) => {
 describe('<Sidebar />', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    useCourseUpgrade.mockReturnValue({ upgradeable: false });
+    useTrackEvent.mockReturnValue({ track: jest.fn() });
     usePromptExperimentDecision.mockReturnValue([]);
   });
 
@@ -80,6 +88,15 @@ describe('<Sidebar />', () => {
     it('should render xpert if disclosureAcknowledged', () => {
       render(undefined, { disclosureAcknowledged: true });
       expect(screen.queryByTestId('sidebar-xpert')).toBeInTheDocument();
+    });
+
+    it('should not render xpert if audit trial is expired', () => {
+      useCourseUpgrade.mockReturnValue({
+        upgradeable: true,
+        auditTrialExpired: true,
+      });
+      render();
+      expect(screen.queryByTestId('sidebar-xpert')).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/UpgradeButton/UpgradeButton.scss
+++ b/src/components/UpgradeButton/UpgradeButton.scss
@@ -1,0 +1,3 @@
+.trial-upgrade {
+  border-radius: 99rem;
+}

--- a/src/components/UpgradeButton/index.jsx
+++ b/src/components/UpgradeButton/index.jsx
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { Button, Icon } from '@openedx/paragon';
+import { LockOpen } from '@openedx/paragon/icons';
+import { useCourseUpgrade, useTrackEvent } from '../../hooks';
+
+import './UpgradeButton.scss';
+
+const UpgradeButton = ({ includeLockIcon, trackingEventName }) => {
+  const { upgradeUrl } = useCourseUpgrade();
+  const { track } = useTrackEvent();
+
+  const handleClick = () => track(trackingEventName);
+
+  return (
+    <Button
+      onClick={handleClick}
+      href={upgradeUrl}
+      className="trial-upgrade mt-3"
+      variant="brand"
+      data-testid="upgrade-cta"
+      block
+    >
+      { includeLockIcon ? <Icon src={LockOpen} className="my-0 mx-2" data-testid="lock-icon" /> : null }
+      Upgrade now
+    </Button>
+  );
+};
+
+UpgradeButton.propTypes = {
+  includeLockIcon: PropTypes.bool,
+  trackingEventName: PropTypes.string.isRequired,
+};
+
+UpgradeButton.defaultProps = {
+  includeLockIcon: false,
+};
+
+export default UpgradeButton;

--- a/src/components/UpgradeButton/index.test.jsx
+++ b/src/components/UpgradeButton/index.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { render } from '../../utils/utils.test';
+import { useCourseUpgrade, useTrackEvent } from '../../hooks';
+
+import UpgradeButton from '.';
+
+jest.mock('../../hooks', () => ({
+  useCourseUpgrade: jest.fn(),
+  useTrackEvent: jest.fn(),
+}));
+
+describe('UpgradeButton', () => {
+  beforeEach(() => {
+    useCourseUpgrade.mockReturnValue({ upgradeUrl: 'www.test.com' });
+    useTrackEvent.mockReturnValue({ track: jest.fn() });
+  });
+
+  it('should render UpgradeButton', () => {
+    render(<UpgradeButton trackingEventName="test.tracking" />);
+    expect(screen.queryByText('Upgrade now')).toBeInTheDocument();
+    expect(screen.queryByTestId('upgrade-cta')).toHaveAttribute('href', 'www.test.com');
+    expect(screen.queryByTestId('lock-icon')).not.toBeInTheDocument();
+  });
+
+  it('should call track event on click', () => {
+    const mockedTrackEvent = jest.fn();
+    useTrackEvent.mockReturnValue({ track: mockedTrackEvent });
+
+    render(<UpgradeButton trackingEventName="test.tracking" />);
+
+    const upgradeCta = screen.queryByTestId('upgrade-cta');
+    expect(mockedTrackEvent).not.toHaveBeenCalled();
+    fireEvent.click(upgradeCta);
+    expect(mockedTrackEvent).toHaveBeenCalledWith('test.tracking');
+  });
+
+  it('should render lock icon', () => {
+    render(<UpgradeButton trackingEventName="test.tracking" includeLockIcon />);
+    expect(screen.queryByTestId('lock-icon')).toBeInTheDocument();
+  });
+});

--- a/src/components/UpgradePanel/UpgradePanel.scss
+++ b/src/components/UpgradePanel/UpgradePanel.scss
@@ -1,0 +1,21 @@
+@use '../../utils/variables';
+
+.upgrade-panel {
+  height: 100%;
+
+  overflow-y: auto;
+  background-color: variables.$dark-green;
+
+  h2 {
+    font-size: 1.375rem;
+  }
+
+  .xpert-value-prop-check {
+    color: variables.$accent-yellow;
+  }
+
+  .xpert-value-prop {
+    margin-bottom: 1rem;
+    font-size: 0.875rem;
+  }
+}

--- a/src/components/UpgradePanel/UpsellBullets/UpsellBullets.jsx
+++ b/src/components/UpgradePanel/UpsellBullets/UpsellBullets.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { Check } from '@openedx/paragon/icons';
+import { Icon, Stack } from '@openedx/paragon';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { getConfig } from '@edx/frontend-platform';
+
+const CheckmarkBullet = () => (
+  <Icon src={Check} className="xpert-value-prop-check" />
+);
+
+export const VerifiedCertBullet = () => {
+  const verifiedCertLink = (
+    <a className="inline-link-underline font-weight-bold text-white" rel="noopener noreferrer" target="_blank" href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}>
+      <FormattedMessage
+        id="advertisements.upsell.verifiedCertBullet.verifiedCert"
+        defaultMessage="verified certificate"
+        description="Bolded words 'verified certificate', which is the name of credential the learner receives."
+      />
+    </a>
+  );
+  return (
+    <Stack direction="horizontal" gap={3} role="listitem" className="align-items-start xpert-value-prop" data-testid="verified-cert-bullet">
+      <CheckmarkBullet />
+      <span>
+        <FormattedMessage
+          id="advertisements.upsell.verifiedCertBullet"
+          defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resumé"
+          description="Bullet showcasing benefit of earned credential."
+          values={{ verifiedCertLink }}
+        />
+      </span>
+    </Stack>
+  );
+};
+
+export const UnlockGradedBullet = () => {
+  const gradedAssignmentsInBoldText = (
+    <span className="font-weight-bold">
+      <FormattedMessage
+        id="advertisements.upsell.unlockGradedBullet.gradedAssignments"
+        defaultMessage="graded assignments"
+        description="Bolded words 'graded assignments', which are the bolded portion of a bullet point highlighting that course content is unlocked when purchasing an upgrade. Graded assignments are any course content that is graded and are unlocked by upgrading to verified certificates."
+      />
+    </span>
+  );
+  return (
+    <Stack direction="horizontal" gap={3} role="listitem" className="align-items-start xpert-value-prop" data-testid="unlock-graded-bullet">
+      <CheckmarkBullet />
+      <span>
+        <FormattedMessage
+          id="advertisements.upsell.unlockGradedBullet"
+          defaultMessage="Unlock your access to all course activities, including {gradedAssignmentsInBoldText}"
+          description="Bullet showcasing benefit of additional course material."
+          values={{ gradedAssignmentsInBoldText }}
+        />
+      </span>
+    </Stack>
+  );
+};
+
+export const FullAccessBullet = () => {
+  const fullAccessInBoldText = (
+    <span className="font-weight-bold">
+      <FormattedMessage
+        id="advertisements.upsell.fullAccessBullet.fullAccess"
+        defaultMessage="Full access"
+        description="Bolded phrase 'Full access', which is the bolded portion of a bullet point highlighting that access to course content will not have time limits."
+      />
+    </span>
+  );
+  return (
+    <Stack direction="horizontal" gap={3} role="listitem" className="align-items-start xpert-value-prop" data-testid="full-access-bullet">
+      <CheckmarkBullet />
+      <span>
+        <FormattedMessage
+          id="advertisements.upsell.fullAccessBullet"
+          defaultMessage="{fullAccessInBoldText} to course content and materials, even after the course ends"
+          description="Bullet showcasing upgrade lifts access durations."
+          values={{ fullAccessInBoldText }}
+        />
+      </span>
+    </Stack>
+  );
+};
+
+export const XpertAccessBullet = () => {
+  const xpertLearningAssistantInBoldText = (
+    <span className="font-weight-bold">
+      <FormattedMessage
+        id="advertisements.upsell.xpertAccessBullet.xpertLearningAssistant"
+        defaultMessage="Xpert Learning Assistant"
+        description="Bolded phrase 'Xpert Learning Assistant', which is the bolded portion of a bullet point highlighting that access to the Xpert Learning Assistant after purchasing an upgrade."
+      />
+    </span>
+  );
+  return (
+    <Stack direction="horizontal" gap={3} role="listitem" className="align-items-start xpert-value-prop" data-testid="xpert-access-bullet">
+      <CheckmarkBullet />
+      <span>
+        <FormattedMessage
+          id="advertisements.upsell.xpertAccessBullet"
+          defaultMessage="Gain full access to {xpertLearningAssistantInBoldText}"
+          description="Bullet showcasing benefit of Xpert Learning Assistant."
+          values={{ xpertLearningAssistantInBoldText }}
+        />
+      </span>
+    </Stack>
+  );
+};

--- a/src/components/UpgradePanel/UpsellBullets/index.jsx
+++ b/src/components/UpgradePanel/UpsellBullets/index.jsx
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import {
+  VerifiedCertBullet,
+  UnlockGradedBullet,
+  FullAccessBullet,
+  XpertAccessBullet,
+} from './UpsellBullets';
+
+const UpsellContent = ({ isFBE }) => (
+  <div role="list" className="pl-4 text-white pt-0 my-4">
+    <XpertAccessBullet />
+    <VerifiedCertBullet />
+    {isFBE && (
+      <>
+        <UnlockGradedBullet />
+        <FullAccessBullet />
+      </>
+    )}
+  </div>
+);
+
+UpsellContent.defaultProps = {
+  isFBE: false,
+};
+
+UpsellContent.propTypes = {
+  isFBE: PropTypes.bool,
+};
+
+export default UpsellContent;

--- a/src/components/UpgradePanel/__snapshots__/index.test.jsx.snap
+++ b/src/components/UpgradePanel/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,717 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UpgradePanel displays correct bullet points if FBE 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="upgrade-panel d-flex flex-column align-items-stretch px-4 py-3"
+      >
+        <h2
+          class="text-light-100"
+        >
+          Upgrade this course
+        </h2>
+        <div
+          class="pl-4 text-white pt-0 my-4"
+          role="list"
+        >
+          <div
+            class="pgn__hstack pgn__stack-gap--3 align-items-start xpert-value-prop"
+            data-testid="xpert-access-bullet"
+            role="listitem"
+          >
+            <span
+              class="pgn__icon xpert-value-prop-check"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                focusable="false"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+            <span>
+              Gain full access to 
+              <span
+                class="font-weight-bold"
+              >
+                Xpert Learning Assistant
+              </span>
+            </span>
+          </div>
+          <div
+            class="pgn__hstack pgn__stack-gap--3 align-items-start xpert-value-prop"
+            data-testid="verified-cert-bullet"
+            role="listitem"
+          >
+            <span
+              class="pgn__icon xpert-value-prop-check"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                focusable="false"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+            <span>
+              Earn a 
+              <a
+                class="inline-link-underline font-weight-bold text-white"
+                href="http://localhost:18000/verified-certificate"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                verified certificate
+              </a>
+               of completion to showcase on your resumé
+            </span>
+          </div>
+          <div
+            class="pgn__hstack pgn__stack-gap--3 align-items-start xpert-value-prop"
+            data-testid="unlock-graded-bullet"
+            role="listitem"
+          >
+            <span
+              class="pgn__icon xpert-value-prop-check"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                focusable="false"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+            <span>
+              Unlock your access to all course activities, including 
+              <span
+                class="font-weight-bold"
+              >
+                graded assignments
+              </span>
+            </span>
+          </div>
+          <div
+            class="pgn__hstack pgn__stack-gap--3 align-items-start xpert-value-prop"
+            data-testid="full-access-bullet"
+            role="listitem"
+          >
+            <span
+              class="pgn__icon xpert-value-prop-check"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                focusable="false"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+            <span>
+              <span
+                class="font-weight-bold"
+              >
+                Full access
+              </span>
+               to course content and materials, even after the course ends
+            </span>
+          </div>
+        </div>
+        <a
+          class="trial-upgrade mt-3 btn btn-brand btn-block"
+          data-testid="upgrade-cta"
+          href="www.test.com"
+        >
+          <span
+            class="pgn__icon my-0 mx-2"
+            data-testid="lock-icon"
+          >
+            <svg
+              aria-hidden="true"
+              fill="none"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M20 8h-3V6.21c0-2.61-1.91-4.94-4.51-5.19A5.008 5.008 0 0 0 7 6h2c0-1.13.6-2.24 1.64-2.7C12.85 2.31 15 3.9 15 6v2H4v14h16V8zm-2 12H6V10h12v10zm-6-3c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+          Upgrade now
+        </a>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="upgrade-panel d-flex flex-column align-items-stretch px-4 py-3"
+    >
+      <h2
+        class="text-light-100"
+      >
+        Upgrade this course
+      </h2>
+      <div
+        class="pl-4 text-white pt-0 my-4"
+        role="list"
+      >
+        <div
+          class="pgn__hstack pgn__stack-gap--3 align-items-start xpert-value-prop"
+          data-testid="xpert-access-bullet"
+          role="listitem"
+        >
+          <span
+            class="pgn__icon xpert-value-prop-check"
+          >
+            <svg
+              aria-hidden="true"
+              fill="none"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+          <span>
+            Gain full access to 
+            <span
+              class="font-weight-bold"
+            >
+              Xpert Learning Assistant
+            </span>
+          </span>
+        </div>
+        <div
+          class="pgn__hstack pgn__stack-gap--3 align-items-start xpert-value-prop"
+          data-testid="verified-cert-bullet"
+          role="listitem"
+        >
+          <span
+            class="pgn__icon xpert-value-prop-check"
+          >
+            <svg
+              aria-hidden="true"
+              fill="none"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+          <span>
+            Earn a 
+            <a
+              class="inline-link-underline font-weight-bold text-white"
+              href="http://localhost:18000/verified-certificate"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              verified certificate
+            </a>
+             of completion to showcase on your resumé
+          </span>
+        </div>
+        <div
+          class="pgn__hstack pgn__stack-gap--3 align-items-start xpert-value-prop"
+          data-testid="unlock-graded-bullet"
+          role="listitem"
+        >
+          <span
+            class="pgn__icon xpert-value-prop-check"
+          >
+            <svg
+              aria-hidden="true"
+              fill="none"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+          <span>
+            Unlock your access to all course activities, including 
+            <span
+              class="font-weight-bold"
+            >
+              graded assignments
+            </span>
+          </span>
+        </div>
+        <div
+          class="pgn__hstack pgn__stack-gap--3 align-items-start xpert-value-prop"
+          data-testid="full-access-bullet"
+          role="listitem"
+        >
+          <span
+            class="pgn__icon xpert-value-prop-check"
+          >
+            <svg
+              aria-hidden="true"
+              fill="none"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+          <span>
+            <span
+              class="font-weight-bold"
+            >
+              Full access
+            </span>
+             to course content and materials, even after the course ends
+          </span>
+        </div>
+      </div>
+      <a
+        class="trial-upgrade mt-3 btn btn-brand btn-block"
+        data-testid="upgrade-cta"
+        href="www.test.com"
+      >
+        <span
+          class="pgn__icon my-0 mx-2"
+          data-testid="lock-icon"
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            focusable="false"
+            height="24"
+            role="img"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M20 8h-3V6.21c0-2.61-1.91-4.94-4.51-5.19A5.008 5.008 0 0 0 7 6h2c0-1.13.6-2.24 1.64-2.7C12.85 2.31 15 3.9 15 6v2H4v14h16V8zm-2 12H6V10h12v10zm-6-3c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        Upgrade now
+      </a>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "store": {
+    "dispatch": [Function],
+    "getState": [Function],
+    "replaceReducer": [Function],
+    "subscribe": [Function],
+    Symbol(Symbol.observable): [Function],
+  },
+  "unmount": [Function],
+}
+`;
+
+exports[`UpgradePanel displays correct bullet points if not FBE 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="upgrade-panel d-flex flex-column align-items-stretch px-4 py-3"
+      >
+        <h2
+          class="text-light-100"
+        >
+          Upgrade this course
+        </h2>
+        <div
+          class="pl-4 text-white pt-0 my-4"
+          role="list"
+        >
+          <div
+            class="pgn__hstack pgn__stack-gap--3 align-items-start xpert-value-prop"
+            data-testid="xpert-access-bullet"
+            role="listitem"
+          >
+            <span
+              class="pgn__icon xpert-value-prop-check"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                focusable="false"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+            <span>
+              Gain full access to 
+              <span
+                class="font-weight-bold"
+              >
+                Xpert Learning Assistant
+              </span>
+            </span>
+          </div>
+          <div
+            class="pgn__hstack pgn__stack-gap--3 align-items-start xpert-value-prop"
+            data-testid="verified-cert-bullet"
+            role="listitem"
+          >
+            <span
+              class="pgn__icon xpert-value-prop-check"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                focusable="false"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+            <span>
+              Earn a 
+              <a
+                class="inline-link-underline font-weight-bold text-white"
+                href="http://localhost:18000/verified-certificate"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                verified certificate
+              </a>
+               of completion to showcase on your resumé
+            </span>
+          </div>
+        </div>
+        <a
+          class="trial-upgrade mt-3 btn btn-brand btn-block"
+          data-testid="upgrade-cta"
+          href="www.test.com"
+        >
+          <span
+            class="pgn__icon my-0 mx-2"
+            data-testid="lock-icon"
+          >
+            <svg
+              aria-hidden="true"
+              fill="none"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M20 8h-3V6.21c0-2.61-1.91-4.94-4.51-5.19A5.008 5.008 0 0 0 7 6h2c0-1.13.6-2.24 1.64-2.7C12.85 2.31 15 3.9 15 6v2H4v14h16V8zm-2 12H6V10h12v10zm-6-3c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+          Upgrade now
+        </a>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="upgrade-panel d-flex flex-column align-items-stretch px-4 py-3"
+    >
+      <h2
+        class="text-light-100"
+      >
+        Upgrade this course
+      </h2>
+      <div
+        class="pl-4 text-white pt-0 my-4"
+        role="list"
+      >
+        <div
+          class="pgn__hstack pgn__stack-gap--3 align-items-start xpert-value-prop"
+          data-testid="xpert-access-bullet"
+          role="listitem"
+        >
+          <span
+            class="pgn__icon xpert-value-prop-check"
+          >
+            <svg
+              aria-hidden="true"
+              fill="none"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+          <span>
+            Gain full access to 
+            <span
+              class="font-weight-bold"
+            >
+              Xpert Learning Assistant
+            </span>
+          </span>
+        </div>
+        <div
+          class="pgn__hstack pgn__stack-gap--3 align-items-start xpert-value-prop"
+          data-testid="verified-cert-bullet"
+          role="listitem"
+        >
+          <span
+            class="pgn__icon xpert-value-prop-check"
+          >
+            <svg
+              aria-hidden="true"
+              fill="none"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+          <span>
+            Earn a 
+            <a
+              class="inline-link-underline font-weight-bold text-white"
+              href="http://localhost:18000/verified-certificate"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              verified certificate
+            </a>
+             of completion to showcase on your resumé
+          </span>
+        </div>
+      </div>
+      <a
+        class="trial-upgrade mt-3 btn btn-brand btn-block"
+        data-testid="upgrade-cta"
+        href="www.test.com"
+      >
+        <span
+          class="pgn__icon my-0 mx-2"
+          data-testid="lock-icon"
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            focusable="false"
+            height="24"
+            role="img"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M20 8h-3V6.21c0-2.61-1.91-4.94-4.51-5.19A5.008 5.008 0 0 0 7 6h2c0-1.13.6-2.24 1.64-2.7C12.85 2.31 15 3.9 15 6v2H4v14h16V8zm-2 12H6V10h12v10zm-6-3c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        Upgrade now
+      </a>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "store": {
+    "dispatch": [Function],
+    "getState": [Function],
+    "replaceReducer": [Function],
+    "subscribe": [Function],
+    Symbol(Symbol.observable): [Function],
+  },
+  "unmount": [Function],
+}
+`;

--- a/src/components/UpgradePanel/index.jsx
+++ b/src/components/UpgradePanel/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { useCourseUpgrade } from '../../hooks';
+import UpsellContent from './UpsellBullets';
+import UpgradeButton from '../UpgradeButton';
+
+import './UpgradePanel.scss';
+
+const UpgradePanel = () => {
+  const { isFBE } = useCourseUpgrade();
+
+  return (
+    <div className="upgrade-panel d-flex flex-column align-items-stretch px-4 py-3">
+      <h2 className="text-light-100">
+        Upgrade this course
+      </h2>
+      <UpsellContent isFBE={isFBE} />
+      <UpgradeButton includeLockIcon trackingEventName="edx.ui.lms.learning_assistant.expired_upgrade_click" />
+    </div>
+  );
+};
+
+export default UpgradePanel;

--- a/src/components/UpgradePanel/index.test.jsx
+++ b/src/components/UpgradePanel/index.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '../../utils/utils.test';
+import { useCourseUpgrade, useTrackEvent } from '../../hooks';
+
+import UpgradePanel from '.';
+
+jest.mock('../../hooks', () => ({
+  useCourseUpgrade: jest.fn(),
+  useTrackEvent: jest.fn(),
+}));
+
+describe('UpgradePanel', () => {
+  beforeEach(() => {
+    useCourseUpgrade.mockReturnValue({ upgradeUrl: 'www.test.com' });
+    useTrackEvent.mockReturnValue({ track: jest.fn() });
+  });
+
+  it('displays correct bullet points if not FBE', () => {
+    useCourseUpgrade.mockReturnValue({
+      upgradeUrl: 'www.test.com',
+      isFBE: false,
+    });
+
+    expect(render(<UpgradePanel />)).toMatchSnapshot();
+  });
+
+  it('displays correct bullet points if FBE', () => {
+    useCourseUpgrade.mockReturnValue({
+      upgradeUrl: 'www.test.com',
+      isFBE: true,
+    });
+
+    expect(render(<UpgradePanel />)).toMatchSnapshot();
+  });
+});

--- a/src/hooks/use-course-upgrade.js
+++ b/src/hooks/use-course-upgrade.js
@@ -30,7 +30,11 @@ const millisecondsInOneDay = 24 * 60 * 60 * 1000; // hours*minutes*seconds*milli
  */
 export default function useCourseUpgrade() {
   const { courseId, isUpgradeEligible } = useContext(CourseInfoContext);
-  const { offer } = useModel('coursewareMeta', courseId);
+  const {
+    offer,
+    accessExpiration,
+    datesBannerInfo,
+  } = useModel('coursewareMeta', courseId);
   const { verifiedMode } = useModel('courseHomeMeta', courseId);
   const {
     auditTrialLengthDays,
@@ -46,11 +50,12 @@ export default function useCourseUpgrade() {
 
   if (auditTrial?.expirationDate) {
     const auditTrialExpirationDate = new Date(auditTrial.expirationDate);
-
     auditTrialDaysRemaining = Math.ceil((auditTrialExpirationDate - Date.now()) / millisecondsInOneDay);
 
     auditTrialExpired = auditTrialDaysRemaining < 0;
   }
+
+  const isFBE = !!accessExpiration && !!datesBannerInfo?.contentTypeGatingEnabled;
 
   return {
     upgradeable: true,
@@ -59,5 +64,6 @@ export default function useCourseUpgrade() {
     auditTrialExpired,
     auditTrial,
     upgradeUrl,
+    isFBE,
   };
 }

--- a/src/widgets/Xpert.jsx
+++ b/src/widgets/Xpert.jsx
@@ -23,7 +23,6 @@ const Xpert = ({
   const {
     isEnabled,
     sidebarIsOpen,
-    auditTrial,
   } = useSelector(state => state.learningAssistant);
 
   const setSidebarIsOpen = (isOpen) => {
@@ -33,16 +32,6 @@ const Xpert = ({
   useEffect(() => {
     dispatch(getLearningAssistantChatSummary(courseId));
   }, [dispatch, courseId]);
-
-  // NOTE: This value can be used later on if/when we pass the enrollment mode to this component
-  const isAuditTrialNotExpired = () => { // eslint-disable-line no-unused-vars
-    const auditTrialExpirationDate = new Date(auditTrial.expirationDate);
-
-    if ((Date.now() - auditTrialExpirationDate) > 0) {
-      return true;
-    }
-    return false;
-  };
 
   return isEnabled ? (
     <CourseInfoProvider value={courseInfo}>


### PR DESCRIPTION
## [COSMO-573](https://2u-internal.atlassian.net/browse/COSMO-573)

When a learner is eligible for upgrade, and their audit trial is expired, an upgrade panel should be shown with a button that takes a learner to the purchase page. Different value props will be shown on the upgrade panel depending on whether or not the course has FBE enabled. The definition for whether or not FBE is enabled has been duplicated from `frontend-plugin-advertisements` (see https://github.com/edx/frontend-plugin-advertisements/blob/7eac0c8caf701c17a2aba1f1dbb5c942aea8c290/src/upgrade-modal/DefaultUpgradeModal.jsx#L71). 

Upgrade panel with FBE:
![Screenshot 2024-12-17 at 11 40 08 AM](https://github.com/user-attachments/assets/a9c2d375-9c6b-40e5-8ce5-3a37c1818a3f)

Upgrade without FBE:
![Screenshot 2024-12-17 at 11 40 35 AM](https://github.com/user-attachments/assets/9e13c2e5-a528-4eec-a661-b0a1f98e733d)
