### PR TITLE
fix: Fixed Paragon scss var reference for CI

### DIFF
--- a/src/components/MessageForm/MessageForm.scss
+++ b/src/components/MessageForm/MessageForm.scss
@@ -1,14 +1,16 @@
+@use '../../utils/variables' as var;
+
 .message-form {
   padding: 0.75rem 1.5rem;
 
   .send-message-input {
     .pgn__form-control-floating-label {
-      color: $gray-300;
+      color: var.$gray-300;
     }
 
     input {
       border-radius: 1rem;
-      border: 1px solid $gray-200;
+      border: 1px solid var.$gray-200;
     }
   }
 
@@ -17,6 +19,6 @@
   }
 
   button {
-    color: $gray-400;
+    color: var.$gray-400;
   }
 }

--- a/src/utils/_variables.scss
+++ b/src/utils/_variables.scss
@@ -1,2 +1,7 @@
 $dark-green: #0e3639;
 $accent-yellow: #f0cc00;
+
+// Paragon variables: https://github.com/edx/brand-edx.org/blob/master/paragon/_variables.scss
+$gray-200: #cccccc !default;
+$gray-300: #adadad !default;
+$gray-400: #8f8f8f !default;


### PR DESCRIPTION
We are using some [Paragon variable references in our SCSS](https://github.com/edx/brand-edx.org/blob/master/paragon/_variables.scss) but these might not be available during the CI checks.

We need to add the vars locally as defaults to workaround this.