### PR TITLE
feat: hide xpert if user is in control variation

### DIFF
--- a/src/widgets/Xpert.jsx
+++ b/src/widgets/Xpert.jsx
@@ -41,12 +41,12 @@ const Xpert = ({
   };
 
   const [decision] = useAuditTrialExperimentDecision();
-  const { enabled, variationKey } = decision || {};
+  const { enabled: experimentEnabled, variationKey } = decision || {};
 
-  const shouldDisplayXpert = () => (
-    // if a user is not part of the experiment, not part of the control, or not eligible for upgrade, they should
-    // still see xpert
-    !enabled
+  // if a user is not part of the experiment, not part of the control, or not eligible for upgrade, they should
+  // still see xpert
+  const shouldDisplayXpert = (
+    !experimentEnabled
     || !(variationKey === OPTIMIZELY_AUDIT_TRIAL_LENGTH_EXPERIMENT_VARIATION_KEYS.CONTROL)
     || isStaff
   );

--- a/src/widgets/Xpert.jsx
+++ b/src/widgets/Xpert.jsx
@@ -54,7 +54,7 @@ const Xpert = ({
   return isEnabled ? (
     <CourseInfoProvider value={courseInfo}>
       <ExperimentsProvider>
-        { shouldDisplayXpert() ? (
+        { shouldDisplayXpert ? (
           <>
             <ToggleXpert
               courseId={courseId}


### PR DESCRIPTION
## [COSMO-667](https://2u-internal.atlassian.net/browse/COSMO-667)

If a user is eligible for upgrade and part of the `control` variation, the Xpert UI should not be visible to them. 