### PR TITLE
fix: update expiration logic to consider trials with 0 or -0 days remaining expired

### DIFF
--- a/src/hooks/use-course-upgrade.js
+++ b/src/hooks/use-course-upgrade.js
@@ -64,7 +64,7 @@ export default function useCourseUpgrade() {
     const auditTrialExpirationDate = new Date(auditTrial.expirationDate);
     auditTrialDaysRemaining = Math.ceil((auditTrialExpirationDate - Date.now()) / millisecondsInOneDay);
 
-    auditTrialExpired = auditTrialDaysRemaining < 0;
+    auditTrialExpired = auditTrialDaysRemaining <= 0;
   }
 
   const isFBE = !!accessExpiration && !!datesBannerInfo?.contentTypeGatingEnabled;

--- a/src/hooks/use-course-upgrade.test.jsx
+++ b/src/hooks/use-course-upgrade.test.jsx
@@ -163,7 +163,11 @@ describe('useCourseUpgrade()', () => {
     });
   });
 
-  it('should return trial info if expired', () => {
+  it.each([
+    ['2024-01-05 09:00:00', -5],
+    ['2024-01-10 08:00:00', -0],
+    ['2024-01-10 09:00:00', 0],
+  ])('should return trial info if expired', (expirationDate, expectedAuditTrialDaysRemaining) => {
     const { result } = renderHook({
       courseInfo: { isUpgradeEligible: true },
       coursewareMeta: {
@@ -180,7 +184,7 @@ describe('useCourseUpgrade()', () => {
         learningAssistant: {
           auditTrialLengthDays: mockedAuditTrialLengthDays,
           auditTrial: {
-            expirationDate: '2024-01-05 09:00:00',
+            expirationDate,
           },
         },
       },
@@ -188,9 +192,9 @@ describe('useCourseUpgrade()', () => {
 
     expect(result.current).toEqual({
       auditTrial: {
-        expirationDate: '2024-01-05 09:00:00',
+        expirationDate,
       },
-      auditTrialDaysRemaining: -5,
+      auditTrialDaysRemaining: expectedAuditTrialDaysRemaining,
       auditTrialExpired: true,
       auditTrialLengthDays: mockedAuditTrialLengthDays,
       upgradeUrl: 'https://upgrade.edx/course/test',


### PR DESCRIPTION
### Description

**Jira**: [COSMO-675](https://2u-internal.atlassian.net/browse/COSMO-675) (private)

This commit updates the logic that is used to determine whether an audit trial is expired. Originally, an audit trial was considered expired if the days remaining was less than 0. This change considers an audit trial expired if the days remaining is less than or equal to 0.

This is consistent with the logic used to determine whether an audit trial is expired on the backend [here](https://github.com/edx/learning-assistant/blob/93d620e49447c54d6e70f7816c6823dcc5eb2534/learning_assistant/api.py#L337).

The bug this commit fixes was that learners that accessed Xpert with an audit trial that expired that day would still be shown Xpert because the days remaining was 0 or -0, and, thus, was not considered expired. Upon submitting a message, they'd receive an error, because the backend considered the audit trial expired.