### PR TITLE
feat: open all hyperlinks in new tab

### DIFF
--- a/src/components/Disclosure/__snapshots__/index.test.jsx.snap
+++ b/src/components/Disclosure/__snapshots__/index.test.jsx.snap
@@ -122,6 +122,7 @@ exports[`<TrialDisclosure /> When trial upgrade being shown should match snapsho
             class="trial-upgrade mt-3 btn btn-brand btn-block"
             data-testid="upgrade-cta"
             href="https://upgrade.edx/course/test"
+            target="_blank"
           >
             Upgrade now
           </a>
@@ -134,9 +135,41 @@ exports[`<TrialDisclosure /> When trial upgrade being shown should match snapsho
         <a
           class="pgn__hyperlink default-link standalone-link privacy-policy-link text-light-100"
           href="https://some.url/policy"
-          target="_self"
+          rel="noopener noreferrer"
+          target="_blank"
         >
           privacy policy
+          <span
+            class="pgn__hyperlink__external-icon"
+            title="Opens in a new tab"
+          >
+            <span
+              class="pgn__icon"
+              data-testid="hyperlink-icon"
+              style="height: 1em; width: 1em;"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                focusable="false"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M19 19H5V5h7V3H3v18h18v-9h-2v7ZM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7Z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span
+                class="sr-only"
+              >
+                in a new tab
+              </span>
+            </span>
+          </span>
         </a>
         .
       </p>
@@ -239,9 +272,41 @@ exports[`<TrialDisclosure /> When trial upgrade is not being shown should match 
         <a
           class="pgn__hyperlink default-link standalone-link privacy-policy-link text-light-100"
           href="https://some.url/policy"
-          target="_self"
+          rel="noopener noreferrer"
+          target="_blank"
         >
           privacy policy
+          <span
+            class="pgn__hyperlink__external-icon"
+            title="Opens in a new tab"
+          >
+            <span
+              class="pgn__icon"
+              data-testid="hyperlink-icon"
+              style="height: 1em; width: 1em;"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                focusable="false"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M19 19H5V5h7V3H3v18h18v-9h-2v7ZM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7Z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span
+                class="sr-only"
+              >
+                in a new tab
+              </span>
+            </span>
+          </span>
         </a>
         .
       </p>

--- a/src/components/Disclosure/index.jsx
+++ b/src/components/Disclosure/index.jsx
@@ -59,6 +59,7 @@ const Disclosure = ({ children }) => {
           Your personal data will be used as described in our &nbsp;
           <Hyperlink
             className="privacy-policy-link text-light-100"
+            target="_blank"
             destination={getConfig().PRIVACY_POLICY_URL}
           >
             privacy policy

--- a/src/components/UpgradeButton/index.jsx
+++ b/src/components/UpgradeButton/index.jsx
@@ -30,6 +30,7 @@ const UpgradeButton = ({ includeLockIcon, trackingEventName }) => {
   return (
     <Button
       onClick={handleClick}
+      target="_blank"
       href={upgradeUrl}
       className="trial-upgrade mt-3"
       variant="brand"

--- a/src/components/UpgradePanel/__snapshots__/index.test.jsx.snap
+++ b/src/components/UpgradePanel/__snapshots__/index.test.jsx.snap
@@ -158,6 +158,7 @@ exports[`UpgradePanel displays correct bullet points if FBE 1`] = `
           class="trial-upgrade mt-3 btn btn-brand btn-block"
           data-testid="upgrade-cta"
           href="www.test.com"
+          target="_blank"
         >
           <span
             class="pgn__icon my-0 mx-2"
@@ -338,6 +339,7 @@ exports[`UpgradePanel displays correct bullet points if FBE 1`] = `
         class="trial-upgrade mt-3 btn btn-brand btn-block"
         data-testid="upgrade-cta"
         href="www.test.com"
+        target="_blank"
       >
         <span
           class="pgn__icon my-0 mx-2"
@@ -516,6 +518,7 @@ exports[`UpgradePanel displays correct bullet points if not FBE 1`] = `
           class="trial-upgrade mt-3 btn btn-brand btn-block"
           data-testid="upgrade-cta"
           href="www.test.com"
+          target="_blank"
         >
           <span
             class="pgn__icon my-0 mx-2"
@@ -630,6 +633,7 @@ exports[`UpgradePanel displays correct bullet points if not FBE 1`] = `
         class="trial-upgrade mt-3 btn btn-brand btn-block"
         data-testid="upgrade-cta"
         href="www.test.com"
+        target="_blank"
       >
         <span
           class="pgn__icon my-0 mx-2"


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/COSMO-677

The following links now open in a new tab rather than on the same tab:

- upgrade link on the intro screen
- privacy policy link on the intro screen
- upgrade link on the final upgrade screen

