### PR TITLE
fix: days remaining banner appears before days remaining is computed

### DIFF
--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -43,6 +43,7 @@
   }
 
   .trial-header {
+    display: flex;
     font-size: 0.9em;
     background-color: var.$brand-100;
     font-size: 0.875rem;
@@ -52,6 +53,10 @@
 
     a {
       text-decoration: underline;
+    }
+
+    &.has-spinner {
+      justify-content: center;
     }
   }
 }

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import {
   Icon,
   IconButton,
+  Spinner,
 } from '@openedx/paragon';
 import { Close } from '@openedx/paragon/icons';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
@@ -76,19 +77,31 @@ const Sidebar = ({
     </a>
   );
 
-  const getDaysRemainingMessage = () => {
+  const getDaysRemainingMessage = () => (
+    auditTrialDaysRemaining === 1 ? (
+      <div data-testid="trial-ends-today-message">
+        Your trial ends today! {getUpgradeLink()} for full access to Xpert.
+      </div>
+    ) : (
+      <div data-testid="days-remaining-message">
+        {auditTrialDaysRemaining} days remaining. {getUpgradeLink()} for full access to Xpert.
+      </div>
+    )
+  );
+
+  const getDaysRemainingHeader = () => {
     if (!upgradeable || auditTrialDaysRemaining < 1) { return null; }
 
+    const shouldShowSpinner = !auditTrialDaysRemaining;
     return (
-      <div className="trial-header" data-testid="get-days-remaining-message">
-        {auditTrialDaysRemaining === 1 ? (
-          <div data-testid="trial-ends-today-message">
-            Your trial ends today! {getUpgradeLink()} for full access to Xpert.
-          </div>
+      <div
+        className={`trial-header ${shouldShowSpinner ? 'has-spinner' : ''}`}
+        data-testid="get-days-remaining-message"
+      >
+        {shouldShowSpinner ? (
+          <Spinner animation="border" className="spinner" data-testid="days-remaining-spinner" screenReaderText="loading" />
         ) : (
-          <div data-testid="days-remaining-message">
-            {auditTrialDaysRemaining} days remaining. {getUpgradeLink()} for full access to Xpert.
-          </div>
+          getDaysRemainingMessage()
         )}
       </div>
     );
@@ -103,7 +116,7 @@ const Sidebar = ({
         <XpertLogo />
       </div>
 
-      {getDaysRemainingMessage()}
+      {getDaysRemainingHeader()}
 
       <ChatBox messageList={messageList} />
       {

--- a/src/components/Sidebar/index.test.jsx
+++ b/src/components/Sidebar/index.test.jsx
@@ -98,6 +98,19 @@ describe('<Sidebar />', () => {
       expect(screen.queryByTestId('sidebar-xpert')).toBeInTheDocument();
     });
 
+    it('If auditTrialDaysRemaining not yet defined, show days remaining', () => {
+      useCourseUpgrade.mockReturnValue({
+        upgradeable: true,
+        upgradeUrl: 'https://mockurl.com',
+        auditTrialDaysRemaining: undefined,
+      });
+      render(undefined, { disclosureAcknowledged: true });
+      expect(screen.queryByTestId('sidebar-xpert')).toBeInTheDocument();
+      expect(screen.queryByTestId('get-days-remaining-message')).toBeInTheDocument();
+      expect(screen.queryByTestId('days-remaining-spinner')).toBeInTheDocument();
+      expect(screen.queryByTestId('days-remaining-message')).not.toBeInTheDocument();
+    });
+
     it('If auditTrialDaysRemaining > 1, show days remaining', () => {
       useCourseUpgrade.mockReturnValue({
         upgradeable: true,
@@ -108,6 +121,7 @@ describe('<Sidebar />', () => {
       expect(screen.queryByTestId('sidebar-xpert')).toBeInTheDocument();
       expect(screen.queryByTestId('get-days-remaining-message')).toBeInTheDocument();
       expect(screen.queryByTestId('days-remaining-message')).toBeInTheDocument();
+      expect(screen.queryByTestId('days-remaining-spinner')).not.toBeInTheDocument();
     });
 
     it('If auditTrialDaysRemaining === 1, say final day', () => {
@@ -120,6 +134,7 @@ describe('<Sidebar />', () => {
       expect(screen.queryByTestId('sidebar-xpert')).toBeInTheDocument();
       expect(screen.queryByTestId('get-days-remaining-message')).toBeInTheDocument();
       expect(screen.queryByTestId('trial-ends-today-message')).toBeInTheDocument();
+      expect(screen.queryByTestId('days-remaining-spinner')).not.toBeInTheDocument();
     });
 
     it('should call track event on click', () => {

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -75,11 +75,10 @@ export function getChatResponse(courseId, unitId, upgradeable, promptExperimentV
         // eslint-disable-next-line no-use-before-define
         dispatch(getLearningAssistantChatSummary(courseId));
       }
-
-      dispatch(setApiIsLoading(false));
       dispatch(addChatMessage(message.role, message.content, courseId, promptExperimentVariationKey));
     } catch (error) {
       dispatch(setApiError());
+    } finally {
       dispatch(setApiIsLoading(false));
     }
   };


### PR DESCRIPTION
### Description

This commit fixes a bug where the days remaining banner appears after an audit trial learner sends their first message. In this case, the days remaining is not displayed until the call to the chat summary endpoint completes. This commit adds a loading spinner to the banner that appears while that call is in progress.

**Jira**: [COSMO-678](https://2u-internal.atlassian.net/browse/COSMO-678)

**Demo**

https://github.com/user-attachments/assets/395aa079-7e72-4cbd-a929-6f48e49b1ee3