### PR TITLE
feat: support paragon to 23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@edx/browserslist-config": "*",
         "@edx/frontend-platform": "^8",
         "@openedx/frontend-build": "^14",
-        "@openedx/paragon": "^22",
+        "@openedx/paragon": "^22 || ^23",
         "@reduxjs/toolkit": "^1.8",
         "prop-types": "^15",
         "react": "^17 || ^18",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@edx/browserslist-config": "*",
     "@edx/frontend-platform": "^8",
     "@openedx/frontend-build": "^14",
-    "@openedx/paragon": "^22",
+    "@openedx/paragon": "^22 || ^23",
     "@reduxjs/toolkit": "^1.8",
     "prop-types": "^15",
     "react": "^17 || ^18",

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,0 @@
-@import "@edx/brand/paragon/fonts.scss";
-@import "@edx/brand/paragon/variables.scss";
-@import "@openedx/paragon/scss/core/core.scss";
-@import "@edx/brand/paragon/overrides.scss";


### PR DESCRIPTION
This PR updates frontend-lib-learning-assistant with the compatibility for CSS Variables and Design Tokens, the new styling paradigm for the frontend. 


**Changes:**

1. Update peerDependencies to allow  `paragon`   version 23.x
2. Delete index.scss 

**Important**
There is a breaking change due to the paragon imports in the index.scss (if it is possible we want to check the relevance of the file otherwise modify it to release a major instead of a major)