### PR TITLE
fix: Upgrade Xpert chat api with feature toggle

### DIFF
--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -67,7 +67,7 @@ export function getChatResponse(courseId, unitId, upgradeable, promptExperimentV
         trackChatBotMessageOptimizely(userId.toString());
       }
       const customQueryParams = promptExperimentVariationKey ? { responseVariation: promptExperimentVariationKey } : {};
-      const message = await fetchChatResponse(courseId, messageList, unitId, customQueryParams);
+      const messages = await fetchChatResponse(courseId, messageList, unitId, customQueryParams);
 
       // Refresh chat summary only on the first message for an upgrade eligible user
       // so we can tell if the user has just initiated an audit trial
@@ -75,7 +75,15 @@ export function getChatResponse(courseId, unitId, upgradeable, promptExperimentV
         // eslint-disable-next-line no-use-before-define
         dispatch(getLearningAssistantChatSummary(courseId));
       }
-      dispatch(addChatMessage(message.role, message.content, courseId, promptExperimentVariationKey));
+      if (process.env.FEATURE_ENABLE_CHAT_V2_ENDPOINT?.toLowerCase() === 'true') {
+        // If the feature is enabled, we will use the new endpoint to fetch messages
+        messages.forEach(msg => {
+          dispatch(addChatMessage(msg.role, msg.content, courseId, promptExperimentVariationKey));
+        });
+      } else {
+        // If the feature is not enabled, we will use the old endpoint to fetch messages
+        dispatch(addChatMessage(messages.role, messages.content, courseId, promptExperimentVariationKey));
+      }
     } catch (error) {
       dispatch(setApiError());
     } finally {

--- a/src/widgets/Xpert.test.jsx
+++ b/src/widgets/Xpert.test.jsx
@@ -77,14 +77,14 @@ beforeEach(() => {
 test('doesn\'t load if not enabled', async () => {
   jest.spyOn(api, 'fetchLearningAssistantChatSummary').mockResolvedValue({ enabled: false });
 
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: initialState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: initialState });
 
   // button to open chat should not be in the DOM
   await waitFor(() => expect(screen.queryByTestId('toggle-button')).not.toBeInTheDocument());
   await waitFor(() => (expect(screen.queryByTestId('action-message')).not.toBeInTheDocument()));
 });
 test('initial load displays correct elements', async () => {
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: initialState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: initialState });
 
   // button to open chat should be in the DOM
   await waitFor(() => expect(screen.queryByTestId('toggle-button')).toBeVisible());
@@ -95,7 +95,7 @@ test('initial load displays correct elements', async () => {
 });
 test('clicking the call to action dismiss button removes the message', async () => {
   const user = userEvent.setup();
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: initialState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: initialState });
 
   // button to open chat should be in the DOM
   await waitFor(() => expect(screen.queryByTestId('toggle-button')).toBeVisible());
@@ -106,13 +106,13 @@ test('clicking the call to action dismiss button removes the message', async () 
   expect(screen.queryByTestId('action-message')).not.toBeInTheDocument();
 
   // re-render exam, button to dismiss cta should not be there
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: initialState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: initialState });
   expect(screen.queryByRole('button', { name: 'dismiss' })).not.toBeInTheDocument();
 });
 test('clicking the call to action opens the sidebar', async () => {
   const user = userEvent.setup();
 
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: initialState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: initialState });
 
   // wait for button to appear
   await screen.findByTestId('message-button');
@@ -130,7 +130,7 @@ test('clicking the call to action opens the sidebar', async () => {
 test('clicking the toggle button opens the sidebar', async () => {
   const user = userEvent.setup();
 
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: initialState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: initialState });
 
   // wait for button to appear
   await screen.findByTestId('toggle-button');
@@ -150,7 +150,7 @@ test('submitted text appears as message in the sidebar', async () => {
   const user = userEvent.setup();
   const userMessage = 'Hello, Xpert!';
 
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: initialState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: initialState });
 
   // wait for button to appear
   await screen.findByTestId('toggle-button');
@@ -175,13 +175,16 @@ test('submitted text appears as message in the sidebar', async () => {
 test('response text appears as message in the sidebar', async () => {
   const user = userEvent.setup();
   const userMessage = 'Hello, Xpert!';
+  
+  // Set environment variable for V2 endpoint
+  process.env.FEATURE_ENABLE_CHAT_V2_ENDPOINT = 'true';
 
   // re-mock the fetchChatResponse API function so that we can assert that the
   // responseMessage appears in the DOM
-  const responseMessage = createRandomResponseForTesting()[0];
+  const responseMessage = createRandomResponseForTesting();
   jest.spyOn(api, 'fetchChatResponse').mockResolvedValue(responseMessage);
 
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: initialState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: initialState });
 
   // wait for button to appear
   await screen.findByTestId('toggle-button');
@@ -193,12 +196,12 @@ test('response text appears as message in the sidebar', async () => {
   await user.type(input, userMessage);
   await user.click(screen.getByRole('button', { name: 'submit' }));
 
-  await screen.findByText(responseMessage.content);
-  expect(screen.getByText(responseMessage.content)).toBeInTheDocument();
+  await screen.findByText(responseMessage[0].content);
+  expect(screen.getByText(responseMessage[0].content)).toBeInTheDocument();
 });
 test('clicking the close button closes the sidebar', async () => {
   const user = userEvent.setup();
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: initialState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: initialState });
 
   // wait for button to appear
   await screen.findByTestId('toggle-button');
@@ -211,7 +214,7 @@ test('clicking the close button closes the sidebar', async () => {
 });
 test('toggle elements do not appear when sidebar is open', async () => {
   const user = userEvent.setup();
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: initialState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: initialState });
 
   // wait for button to appear
   await screen.findByTestId('toggle-button');
@@ -225,6 +228,10 @@ test('error message should disappear upon succesful api call', async () => {
   const user = userEvent.setup();
   const userMessage = 'Hello, Xpert!';
 
+  // Mock fetchChatResponse to return a successful response
+  const responseMessage = createRandomResponseForTesting();
+  jest.spyOn(api, 'fetchChatResponse').mockResolvedValue(responseMessage);
+
   const errorState = {
     learningAssistant: {
       currentMessage: '',
@@ -237,7 +244,7 @@ test('error message should disappear upon succesful api call', async () => {
       sidebarIsOpen: false,
     },
   };
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: errorState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: errorState });
 
   // wait for button to appear
   await screen.findByTestId('toggle-button');
@@ -271,7 +278,7 @@ test('error message should disappear when dismissed', async () => {
       sidebarIsOpen: false,
     },
   };
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: errorState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: errorState });
 
   // wait for button to appear
   await screen.findByTestId('toggle-button');
@@ -289,7 +296,7 @@ test('popup modal should open chat', async () => {
   const user = userEvent.setup();
   window.localStorage.clear();
 
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: initialState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: initialState });
 
   // wait for button to appear
   await screen.findByTestId('toggle-button');
@@ -311,7 +318,7 @@ test('popup modal should close and display CTA', async () => {
   const user = userEvent.setup();
   window.localStorage.clear();
 
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />, { preloadedState: initialState });
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />, { preloadedState: initialState });
 
   // wait for button to appear
   await screen.findByTestId('toggle-button');
@@ -342,7 +349,7 @@ test('survey monkey survey should appear after closing sidebar', async () => {
   const survey = jest.spyOn(surveyMonkey, 'default').mockReturnValueOnce(1);
   const user = userEvent.setup();
 
-  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />);
+  render(<Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />);
 
   // wait for button to appear
   await screen.findByTestId('toggle-button');
@@ -363,7 +370,7 @@ test('Xpert is not rendered for control group', async () => {
   }]);
 
   render(
-    <Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} />,
+    <Xpert courseId={courseId} contentToolsEnabled={false} unitId={unitId} isUpgradeEligible={false} />,
     { preloadedState: initialState },
   );
 


### PR DESCRIPTION
This pull request introduces changes to improve the handling of chat responses and testing functionality in the learning assistant feature. The most significant updates include supporting a new V2 endpoint for fetching chat messages, enhancing unit tests for `getChatResponse`, and adding the `isUpgradeEligible` prop to the `Xpert` component across multiple tests.

### Chat Response Handling Updates:
* Modified `getChatResponse` in `src/data/thunks.js` to support the V2 endpoint, allowing multiple messages to be processed when the feature flag `FEATURE_ENABLE_CHAT_V2_ENDPOINT` is enabled.

### Unit Test Enhancements:
* Added comprehensive unit tests in `src/data/thunks.test.js` for `getChatResponse`, covering scenarios for V2 endpoint behavior, error handling, and prompt experiment variation key usage.
* Refactored `beforeEach` and `afterEach` in `src/data/thunks.test.js` to improve test setup and teardown, including resetting environment variables and mocks selectively.

### Component Prop Updates:
* Updated all test cases in `src/widgets/Xpert.test.jsx` to include the new `isUpgradeEligible` prop in the `Xpert` component, ensuring consistency and support for upgrade eligibility logic. [[1]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L80-R87) [[2]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L98-R98) [[3]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L109-R115) [[4]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L133-R133) [[5]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L153-R153) [[6]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9R179-R187) [[7]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L196-R204) [[8]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L214-R217) [[9]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L240-R247) [[10]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L274-R281) [[11]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L292-R299) [[12]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L314-R321) [[13]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L345-R352) [[14]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L366-R373)

These changes collectively enhance the functionality, reliability, and test coverage of the learning assistant feature.