### PR TITLE
feat: Implement feature toggle for chat response endpoint

### DIFF
--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -75,9 +75,15 @@ export function getChatResponse(courseId, unitId, upgradeable, promptExperimentV
         // eslint-disable-next-line no-use-before-define
         dispatch(getLearningAssistantChatSummary(courseId));
       }
-      messages.forEach(msg => {
-        dispatch(addChatMessage(msg.role, msg.content, courseId, promptExperimentVariationKey));
-      });
+      if (process.env.FEATURE_ENABLE_CHAT_V2_ENDPOINT?.toLowerCase() === 'true') {
+        // If the feature is enabled, handle array response format from the new endpoint version
+        messages.forEach(msg => {
+          dispatch(addChatMessage(msg.role, msg.content, courseId, promptExperimentVariationKey));
+        });
+      } else {
+        // If the feature is not enabled, handle the response as a single object (legacy format)
+        dispatch(addChatMessage(messages.role, messages.content, courseId, promptExperimentVariationKey));
+      }
     } catch (error) {
       dispatch(setApiError());
     } finally {


### PR DESCRIPTION
This pull request introduces support for a feature flag (`FEATURE_ENABLE_CHAT_V2_ENDPOINT`) to toggle between old and new chat endpoints, along with corresponding updates to unit tests. Additionally, it modifies test cases for the `Xpert` widget to include a new `isUpgradeEligible` prop, ensuring consistency across tests.

### Feature Flag Implementation for Chat Endpoints:
* [`src/data/thunks.js`](diffhunk://#diff-f708120055e193e6e1c566fefb57a208b514e2fd0f8944fc91ee1f0c97b0cd34R78-R86): Added logic to check the `FEATURE_ENABLE_CHAT_V2_ENDPOINT` flag and dispatch messages differently based on the flag's value. This enables toggling between the old and new chat endpoints.

### Unit Test Enhancements for Chat Endpoints:
* [`src/data/thunks.test.js`](diffhunk://#diff-64688506fa5a6fcbe2cd60fea5be1774aae123fd6fb19fcda6906aa8ce2c7635R78-R86): Added test cases to validate behavior when the `FEATURE_ENABLE_CHAT_V2_ENDPOINT` flag is enabled, disabled, or unset. These tests ensure the application correctly handles API responses based on the flag's state. [[1]](diffhunk://#diff-64688506fa5a6fcbe2cd60fea5be1774aae123fd6fb19fcda6906aa8ce2c7635R78-R86) [[2]](diffhunk://#diff-64688506fa5a6fcbe2cd60fea5be1774aae123fd6fb19fcda6906aa8ce2c7635R139-R205) [[3]](diffhunk://#diff-64688506fa5a6fcbe2cd60fea5be1774aae123fd6fb19fcda6906aa8ce2c7635R229-R231)

### Updates to `Xpert` Widget Test Cases:
* [`src/widgets/Xpert.test.jsx`](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L80-R93): Updated multiple test cases to include the new `isUpgradeEligible` prop in the `Xpert` component, ensuring consistent rendering behavior across all tests. [[1]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L80-R93) [[2]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L179-R221) [[3]](diffhunk://#diff-192051ee16edb7db55ae9e5fcd56b5946d74b1750049033aeece1fab98d08dc9L349-R405)…tests